### PR TITLE
Add Constraint type variable to StateMachine

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -16,7 +16,7 @@ extra-source-files:  README.md
                    , CHANGELOG.md
                    , CONTRIBUTING.md
 cabal-version:       >=1.10
-tested-with:         GHC == 8.4.3, GHC == 8.6.5, GHC == 8.8.3
+tested-with:         GHC == 8.4.3, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.7
 
 library
   hs-source-dirs:      src
@@ -30,6 +30,8 @@ library
               -Wno-safe
               -Wno-missing-local-signatures
               -Wno-monomorphism-restriction
+              -Wno-prepositive-qualified-module
+              -Wno-missing-safe-haskell-mode
   exposed-modules:     Test.StateMachine
                      , Test.StateMachine.BoxDrawer
                      , Test.StateMachine.ConstructorName
@@ -93,7 +95,6 @@ test-suite quickcheck-state-machine-test
                        hashable,
                        hashtables,
                        hs-rqlite >= 0.1.2.0,
-                       HTTP,
                        http-client,
                        monad-logger,
                        mtl,
@@ -125,7 +126,6 @@ test-suite quickcheck-state-machine-test
                        tasty-quickcheck,
                        text,
                        tree-diff,
-                       time,
                        vector >=0.12.0.1,
                        wai,
                        warp,
@@ -164,6 +164,8 @@ test-suite quickcheck-state-machine-test
               -Wno-safe
               -Wno-missing-local-signatures
               -Wno-monomorphism-restriction
+              -Wno-prepositive-qualified-module
+              -Wno-missing-safe-haskell-mode
   default-language:    Haskell2010
 
 source-repository head

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -50,7 +50,8 @@ module Test.StateMachine
   , commandNamesParallel
 
     -- * Types
-  , StateMachine(StateMachine)
+  , StateMachine'(StateMachine)
+  , StateMachine
   , Concrete
   , Symbolic
   , Reference

--- a/src/Test/StateMachine/Lockstep/NAry.hs
+++ b/src/Test/StateMachine/Lockstep/NAry.hs
@@ -375,7 +375,7 @@ precondition (Model _ (Refss hs)) (At c) =
     sameRef (QSM.Reference (QSM.Symbolic v)) (QSM.Reference (QSM.Symbolic v')) = v == v'
 
 toStateMachine :: StateMachineTest t m
-               -> StateMachine (Model t) (At (Cmd t)) m (At (Resp t))
+               -> StateMachine' Top (Model t) (At (Cmd t)) m (At (Resp t))
 toStateMachine sm@StateMachineTest{} = StateMachine {
       initModel     = initModel     sm
     , transition    = transition    sm

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE DeriveFoldable             #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveTraversable          #-}
@@ -22,7 +23,8 @@
 -----------------------------------------------------------------------------
 
 module Test.StateMachine.Types
-  ( StateMachine(..)
+  ( StateMachine'(..)
+  , StateMachine
   , Command(..)
   , getCommand
   , Commands(..)
@@ -47,6 +49,8 @@ module Test.StateMachine.Types
 import           Data.Functor.Classes
                    (Ord1, Show1)
 import           Data.Semigroup
+import           Data.SOP.Constraint
+                   (Top)
 import           Prelude
 import           Test.QuickCheck
                    (Gen)
@@ -59,9 +63,11 @@ import           Test.StateMachine.Types.References
 
 ------------------------------------------------------------------------
 
-data StateMachine model cmd m resp = StateMachine
-  { initModel      :: forall r. model r
-  , transition     :: forall r. (Show1 r, Ord1 r) => model r -> cmd r -> resp r -> model r
+type StateMachine model cmd m resp = StateMachine' Top model cmd m resp
+
+data StateMachine' c model cmd m resp = StateMachine
+  { initModel      :: forall r. c r => model r
+  , transition     :: forall r. (c r, Show1 r, Ord1 r) => model r -> cmd r -> resp r -> model r
   , precondition   :: model Symbolic -> cmd Symbolic -> Logic
   , postcondition  :: model Concrete -> cmd Concrete -> resp Concrete -> Logic
   , invariant      :: Maybe (model Concrete -> Logic)

--- a/src/Test/StateMachine/Types/References.hs
+++ b/src/Test/StateMachine/Types/References.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 
 -----------------------------------------------------------------------------
@@ -24,6 +25,8 @@
 module Test.StateMachine.Types.References
   ( Var(Var)
   , Symbolic(Symbolic)
+  , SymbOrConcrete(..)
+  , SSymbOrConcrete(..)
   , Concrete(Concrete)
   , Reference(Reference)
   , reference
@@ -37,6 +40,7 @@ module Test.StateMachine.Types.References
 import           Data.Functor.Classes
                    (Eq1, Ord1, Show1, compare1, eq1, liftCompare,
                    liftEq, liftShowsPrec, showsPrec1)
+import           Data.Proxy
 import           Data.TreeDiff
                    (Expr(App), ToExpr, toExpr)
 import           Data.Typeable
@@ -147,3 +151,16 @@ instance Show (Opaque a) where
 
 instance ToExpr (Opaque a) where
   toExpr _ = App "Opaque" []
+
+class SymbOrConcrete r where
+  soc :: Proxy r -> SSymbOrConcrete r
+
+data SSymbOrConcrete r where
+  SSymbolic :: SSymbOrConcrete Symbolic
+  SConcrete :: SSymbOrConcrete Concrete
+
+instance SymbOrConcrete Symbolic where
+  soc _ = SSymbolic
+
+instance SymbOrConcrete Concrete where
+  soc _ = SConcrete

--- a/src/Test/StateMachine/Utils.hs
+++ b/src/Test/StateMachine/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE NamedFieldPuns      #-}
@@ -190,7 +191,7 @@ pickOneReturnRestL ls = concatMap
 
 -----------------------------------------------------------------------------
 
-mkModel :: StateMachine model cmd m resp -> History cmd resp  -> model Concrete
+mkModel :: c Concrete => StateMachine' c model cmd m resp -> History cmd resp  -> model Concrete
 mkModel StateMachine {transition, initModel} =
   go initModel . operationsPath . interleavings . unHistory
     where

--- a/test/ProcessRegistry.hs
+++ b/test/ProcessRegistry.hs
@@ -315,7 +315,7 @@ precondition Model {..} act = case act of
   Exit                 -> Top
 
 postcondition :: Model Concrete -> Action Concrete -> Response Concrete -> Logic
-postcondition Model {..} act (Response (Left err))   = case act of
+postcondition _model act (Response (Left err))   = case act of
   BadRegister _name _pid -> Top
   BadUnregister _name    -> Top
   _                      -> Bot .// show err

--- a/test/RQlite.hs
+++ b/test/RQlite.hs
@@ -34,7 +34,7 @@ import           Data.Aeson                         hiding
 import           Data.Foldable
 import           Data.Functor.Classes
 import           Data.Kind
-import           Data.List
+import qualified Data.List                          as L
 import           Data.Map
                    (Map)
 import qualified Data.Map                           as M
@@ -278,7 +278,7 @@ createRQNetworks = do
 ------------------------
 
 sameElements :: Eq a => [a] -> [a] -> Bool
-sameElements x y = null (x \\ y) && null (y \\ x)
+sameElements x y = null (x L.\\ y) && null (y L.\\ x)
 
 type NodeRef =  Reference Container
 
@@ -562,7 +562,7 @@ precondition (Model DBModel{..} nodes) (At cmd) = case cmd of
     Delay _    -> Top
 
 postcondition :: Model Concrete -> At Cmd Concrete -> At Resp Concrete -> Logic
-postcondition m@Model{..} cmd resp =
+postcondition m cmd resp =
     toMock (eventAfter ev) resp .== eventMockResp ev
     where
         ev = lockstep m cmd resp
@@ -731,7 +731,7 @@ joinNode :: Bool -> Map Int NodeState -> Maybe Int
 joinNode avoid0 ndState =
     case snd <$> getRunning ndState of
         [] -> Nothing
-        rs -> Just $ case (elem 0 rs, delete 0 rs, avoid0) of
+        rs -> Just $ case (elem 0 rs, L.delete 0 rs, avoid0) of
             (False, _, _)     -> head rs
             (True, _, False)  -> 0
             (True, rs', True) -> head rs'

--- a/test/SQLite.hs
+++ b/test/SQLite.hs
@@ -38,8 +38,6 @@ import           Data.Bitraversable
 import           Data.Functor.Classes
 import           Data.Kind
                    (Type)
-import           Data.List                     hiding
-                   (insert)
 import           Data.Maybe
                    (fromMaybe)
 import           Data.Pool
@@ -287,7 +285,7 @@ smUnused :: StateMachine Model (At Cmd) IO (At Resp)
 smUnused = sm undefined undefined undefined
 
 generatorImpl :: Model Symbolic -> Maybe (Gen (At Cmd Symbolic))
-generatorImpl Model {..} = Just $ At <$>
+generatorImpl _model = Just $ At <$>
     frequency [ (3, Insert <$> arbitrary)
               , (3, SelectList <$> arbitrary)
               ]


### PR DESCRIPTION
While working on some QSM parallel tests I think I realized the following:

The model that is advanced by the responses of the (parallel) SUT execution, is sometimes more ignorant/less intelligent than the model that is advanced by the mock responses. The model that is used for generating the commands or shrinking has to keep track of some state to make a "best effort" for generating useful commands, however the parallel execution might result in a different path of execution which can lead to completely different results. Therefore sometimes the "running model"  has troubles defining some fields from the responses as the actual change in the system might be hidden. Of course, on some phases the model could carry some `undefined`s on some lazy fields and run without issues. However, I prefer not having those fields depending on the situation.

Therefore the solution I propose is to add a new type parameter of kind `Type -> Constraint` to the (now renamed) `StateMachine'` datatype. I also provide a backwards compatible alias `StateMachine` which fixes the variable to `Top` which is trivially satisfied always (I think this is an important :exclamation: point)

But on other cases, a user might choose to provide some other constraint, in particular the one I am proposing is `SymbOrConcrete` (name subject to discussion). This way, the user can then use the pattern matching on the GADT to get back the singleton that lets him know whether it is running on generation style or on execution style.



<details>
  <summary>Motivating example</summary>
  
  I think I should include a motivating example to explain why I'm proposing this change as only the explanation might just look like some convoluted machinery. At work (blockchain) I'm writing a parallel QSM test for a component named Mempool. It represents the set of transactions that are valid at the top of the currently selected chain. The thing is that when generating commands I need to generate transactions which have a high change of being accepted, but a separate command switches completely the selected chain and at that point transactions are revalidated and so on. Therefore when generating commands I can keep track of the tip of the chain and the current transactions, but when running the responses from the system I only want to check that an "atomic global counter" indeed does never repeat because I have no way to tell when exactly a switch happened in the RTS scheduling. Therefore the `Model Concrete` is much simpler than the `Model Symbolic` and I thought about this way of representing it. If you want to see how I used it, you can check [this](https://github.com/input-output-hk/ouroboros-network/blob/0d59ced0bdc142e199ffb9cd6cb0af39538a8454/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/StateMachine.hs#L180-L207) and [this](https://github.com/input-output-hk/ouroboros-network/blob/0d59ced0bdc142e199ffb9cd6cb0af39538a8454/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/StateMachine.hs#L297-L299)

It is actually using a slightly different version in which the `c` variable is not present, but it is always fixed to `SymbOrConcrete` in `transition` and in `initialModel`.
</details>


Feel free to criticize the changes or if  some more explanation/motivation is needed let me know.

I also took the opportunity to cleanup a couple of imports, GHC warnings.