### PR TITLE
Cleanup improvements

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -51,9 +51,6 @@
 # Ignore some builtin hints
 # - ignore: {name: Use let}
 # - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
-- ignore: {name: Use curry, within: Test.StateMachine.Internal.Sequential.liftSem}
-- ignore: {name: Use foldl, within: Test.StateMachine.Internal.Parallel.liftShrinkFork}
-
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+#### 0.7.3 (???)
+
+  * Fix compatibility with GHC 9.6 (PR #20, thanks @erikd);
+
+  * Fix printing of boxed diagrams of parallel properties (PR #21);
+
+  * Parallel properties will now show a message indicating what looks like it
+    could be the cause of the property failing (PR #21).
+
 #### 0.7.2 (2023-4-20)
 
   * Fix compatibility with GHC 9.0 and 9.2 (PR #7, thanks @edsko);

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ ParallelCommands
 └──────────────────────────────────────────────┘ │
 
 AnnotateC "Read" (PredicateC (1 :/= 2))
+
+However, some repetitions of this sequence of commands passed. Maybe there is a race condition?
 ```
 
 As we can see above, a mutable reference is first created, and then in
@@ -433,6 +435,32 @@ actually executed several times by default, i.e. steps 2 to 7 will be executed
 multiple times for the same test case expecting that the scheduling of events
 varies between runs. One can further increase entropy by introducing random
 `threadDelay`s in the semantic function.
+
+#### Why is a parallel property failing?
+
+Unless in presence of more severe bugs, parallel properties can fail because of
+mainly two reasons: a race condition is happening or a logic bug is present in
+the code. Taking advantage of the fact that we are repeating multiple times each
+sequence of commands, we can have some insight on which one of those cases seems
+to be the cause.
+
+The parallel counterexample will show one of the following messages:
+
+- `However, some repetitions of this sequence of commands passed. Maybe there is
+  a race condition?`: In this case as some parallel executions of a given
+  sequence of commands have passed, it seems that the test outcome is being
+  affected by a race condition or a non-deterministic error. This message is
+  accurate in the sense that a logic bug will not result in some repetitions
+  succeeding.
+- `And all repetitions of this sequence of commands failed. Maybe there is a
+  logic bug? Try with more repetitions to be sure that it happens consistently`:
+  In this case, one of two things can happen. Either there is a logic bug that
+  is triggered always (which is what the message suggest) or we were just super
+  unlucky (or super lucky, as we found an error) in this run and a race
+  condition manifested in all runs. In order to rule out this last case, one can
+  run the tests with more repetitions, which if the problem is that there is
+  indeed a race condition, should result in the other message being printed
+  instead.
 
 #### SUT initialization
 

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ defining the state machine inside a monadic action and use the
 
 ``` haskell
 
-semantics :: Env -> Command Concrete -> m Response Concrete
+semantics :: Env -> Command Concrete -> m (Response Concrete)
 semantics = ...
 
 sm :: m (StateMachine Model Command m Response)
@@ -526,7 +526,7 @@ Here are some more examples to get you started:
     has no meaningful semantics, we merely model-check. It might be helpful to
     compare the solution to the
     Hedgehog
-    [solution](http://clrnd.com.ar/posts/2017-04-21-the-water-jug-problem-in-hedgehog.html) and
+    [solution](https://clrnd.com.ar/posts/2017-04-21-the-water-jug-problem-in-hedgehog.html) and
     the
     TLA+
     [solution](https://github.com/tlaplus/Examples/blob/master/specifications/DieHard/DieHard.tla);
@@ -548,7 +548,7 @@ Here are some more examples to get you started:
     -- another example that shows how the sequential property can find help find
     different kind of bugs. This example is borrowed from the paper *Testing the
     Hard Stuff and Staying Sane*
-    [[PDF](http://publications.lib.chalmers.se/records/fulltext/232550/local_232550.pdf),
+    [[PDF](https://publications.lib.chalmers.se/records/fulltext/232550/local_232550.pdf),
     [video](https://www.youtube.com/watch?v=zi0rHwfiX1Q)]. For a more direct
     translation from the paper, see the following
     [variant](https://github.com/polux/qsm-ffi-demo) which uses the C FFI;
@@ -558,7 +558,7 @@ Here are some more examples to get you started:
     -- an imperative implementation of the union-find algorithm. It could be
     useful to compare the solution to the one that appears in the paper *Testing
     Monadic Code with QuickCheck*
-    [[PS](http://www.cse.chalmers.se/~rjmh/Papers/QuickCheckST.ps)], which the
+    [[PS](https://www.cse.chalmers.se/~rjmh/Papers/QuickCheckST.ps)], which the
     [`Test.QuickCheck.Monadic`](https://hackage.haskell.org/package/QuickCheck/docs/Test-QuickCheck-Monadic.html)
     module is based on;
 
@@ -571,7 +571,7 @@ Here are some more examples to get you started:
     *Testing a Database for Race Conditions with QuickCheck* and *Testing the
     Hard Stuff and Staying
     Sane*
-    [[PDF](http://publications.lib.chalmers.se/records/fulltext/232550/local_232550.pdf),
+    [[PDF](https://publications.lib.chalmers.se/records/fulltext/232550/local_232550.pdf),
     [video](https://www.youtube.com/watch?v=zi0rHwfiX1Q)] papers;
 
   * CRUD webserver where create returns unique
@@ -603,7 +603,7 @@ Here are some more examples to get you started:
     [video](https://www.youtube.com/watch?v=w2fin2V83e8)] papers.
 
 All properties from the examples can be found in the
-[`Spec`](https://github.com/stevana/quickcheck-state-machine/tree/master/test/Spec.hs)
+[`Spec`](https://github.com/stevana/quickcheck-state-machine/blob/master/test/Spec.hs)
 module located in the
 [`test`](https://github.com/stevana/quickcheck-state-machine/tree/master/test)
 directory.
@@ -620,7 +620,7 @@ More examples from the "real world":
   * IOHK are using a state machine models in several
     [places](https://github.com/search?l=Haskell&q=org%3Ainput-output-hk+Test.StateMachine&type=Code).
     For example
-    [here](https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs)
+    [here](https://github.com/input-output-hk/fs-sim/blob/main/fs-sim/test/Test/System/FS/StateMachine.hs)
     is a test of a mock file system that they in turn use to simulate file
     system errors when testing a blockchain database. The following blog
     [post](http://www.well-typed.com/blog/2019/01/qsm-in-depth/) describes their
@@ -650,14 +650,14 @@ we can improve it on the issue tracker!
     QuickCheck started;
 
   * John Hughes' Midlands Graduate School 2019
-    [course](http://www.cse.chalmers.se/~rjmh/MGS2019/) on property-based
+    [course](https://www.cse.chalmers.se/~rjmh/MGS2019/) on property-based
     testing, which covers the basics of state machine modelling and testing. It
     also contains a minimal implementation of a state machine testing library
     built on top of Haskell's QuickCheck;
 
   * *Finding Race Conditions in Erlang with QuickCheck and
     PULSE*
-    [[PDF](http://www.cse.chalmers.se/~nicsma/papers/finding-race-conditions.pdf),
+    [[PDF](https://www.cse.chalmers.se/~nicsma/papers/finding-race-conditions.pdf),
     [video](https://vimeo.com/6638041)] -- this is the first paper to describe
     how Erlang's QuickCheck works (including the parallel testing);
 
@@ -713,7 +713,7 @@ we can improve it on the issue tracker!
             status report of the hypervisor that Microsoft Research are
             developing using Event-B.
 
-      - [Abstract State Machines](http://www.di.unipi.it/~boerger/AsmBook/): A
+      - [Abstract State Machines](http://groups.di.unipi.it/~boerger/AsmBook/): A
         Method for High-Level System Design and Analysis.
 
     The books contain general advice how to model systems using state machines,
@@ -735,7 +735,7 @@ we can improve it on the issue tracker!
         property based testing library to have support for state machines
         (closed source);
 
-      - The Erlang library [PropEr](https://github.com/manopapad/proper) is
+      - The Erlang library [PropEr](https://github.com/proper-testing/proper) is
         *eqc*-inspired, open source, and has support for state
         machine [testing](http://propertesting.com/);
 
@@ -743,10 +743,10 @@ we can improve it on the issue tracker!
         library [Hedgehog](https://github.com/hedgehogqa/haskell-hedgehog), also
         has support for state machine based testing;
 
-      - [ScalaCheck](http://www.scalacheck.org/), likewise has support for state
+      - [ScalaCheck](https://scalacheck.org/), likewise has support for state
         machine
         based
-        [testing](https://github.com/rickynils/scalacheck/blob/master/doc/UserGuide.md#stateful-testing) (no
+        [testing](https://github.com/typelevel/scalacheck/blob/master/doc/UserGuide.md) (no
         parallel property);
 
       - The Python

--- a/src/Test/StateMachine/BoxDrawer.hs
+++ b/src/Test/StateMachine/BoxDrawer.hs
@@ -102,5 +102,6 @@ data Fork a = Fork a a a
 exec :: [(EventType, Pid)] -> Fork [String] -> Doc
 exec evT (Fork lops pops rops) = vsep $ map text (preBoxes ++ parBoxes)
   where
-    preBoxes = map (adjust $ maximum $ 0:map ((2+) . length) (take 1 parBoxes)) $ compilePrefix pops
+    preBoxes = let pref = compilePrefix pops
+               in map (adjust $ maximum $ map ((2+) . size) pref ++ map ((2+) . length) (take 1 parBoxes)) pref
     parBoxes = next . compile $ toEvent evT (lops, rops)

--- a/src/Test/StateMachine/DotDrawing.hs
+++ b/src/Test/StateMachine/DotDrawing.hs
@@ -71,17 +71,17 @@ printDotGraph GraphOptions{..} (Rose pref sfx) = do
             in (p, n, e)
         nodes = concatMap (\(_,n,_) -> n) nodesAndEdges
         edges = concatMap (\(_,_,e) -> e) nodesAndEdges
-        firstOfEachPid = (\(p, n, _) -> (p, fmap fst $ uncons n)) <$> nodesAndEdges
+        firstOfEachPid = (\(p, n, _) -> (p, fst <$> uncons n)) <$> nodesAndEdges
 
         -- create barrier edges
 
-        edgesFromBarrier = concat $ (\(p, mn) -> case mn of
+        edgesFromBarrier = concatMap (\(p, mn) -> case mn of
                             Nothing -> []
                             Just n -> [DotEdge {
                                       fromNode = nodeID barrierNode
                                     , toNode = nodeID n
                                     , edgeAttributes = [TailPort (LabelledPort (PN {portName = pack $ show p}) Nothing)]
-                                    }]) <$> firstOfEachPid
+                                    }]) firstOfEachPid
         prefixToBarrier = case prefixNodes of
             [] -> []
             _  -> [DotEdge {
@@ -118,11 +118,11 @@ printDotGraph GraphOptions{..} (Rose pref sfx) = do
 toDotNode :: String -> (Int, (String,String)) -> DotNode String
 toDotNode nodeIdGroup (n, (invocation, resp)) =
     DotNode {
-          nodeID = (nodeIdGroup ++ "-" ++ show n)
+          nodeID = nodeIdGroup ++ "-" ++ show n
         , nodeAttributes = [Label $ StrLabel $ pack $
-                (newLinesAfter "\\l" 60 invocation)
+                newLinesAfter "\\l" 60 invocation
                 ++ "\\n"
-                ++ (newLinesAfter "\\r" 60 resp)]
+                ++ newLinesAfter "\\r" 60 resp]
     }
 
 byTwoUnsafe :: String -> [a] -> [(a,a)]

--- a/src/Test/StateMachine/Lockstep/Auxiliary.hs
+++ b/src/Test/StateMachine/Lockstep/Auxiliary.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -61,7 +60,7 @@ class NTraversable (f :: (k -> Type) -> [k] -> Type) where
 ntraverse :: (NTraversable f, Applicative m, SListI xs)
           => (forall a. Elem xs a -> g a -> m (h a))
           -> f g xs -> m (f h xs)
-ntraverse f  = nctraverse (Proxy @Top) f
+ntraverse = nctraverse (Proxy @Top)
 
 ncfmap :: (NTraversable f, All c xs)
        => proxy c
@@ -72,7 +71,7 @@ ncfmap p f xs = unI $ nctraverse p (\ix -> I . f ix) xs
 nfmap :: (NTraversable f, SListI xs)
       => (forall a. Elem xs a -> g a -> h a)
       -> f g xs -> f h xs
-nfmap f xs = ncfmap (Proxy @Top) f xs
+nfmap = ncfmap (Proxy @Top)
 
 ncfoldMap :: forall proxy f g m c xs.
              (NTraversable f, Monoid m, All c xs)
@@ -82,7 +81,7 @@ ncfoldMap :: forall proxy f g m c xs.
 ncfoldMap p f = \xs -> execState (aux xs) mempty
   where
     aux :: f g xs -> State m (f g xs)
-    aux xs = nctraverse p aux' xs
+    aux = nctraverse p aux'
 
     aux' :: c a => Elem xs a -> g a -> State m (g a)
     aux' ix ga = modify (f ix ga `mappend`) >> return ga
@@ -90,4 +89,4 @@ ncfoldMap p f = \xs -> execState (aux xs) mempty
 nfoldMap :: (NTraversable f, Monoid m, SListI xs)
          => (forall a. Elem xs a -> g a -> m)
          -> f g xs -> m
-nfoldMap f xs = ncfoldMap (Proxy @Top) f xs
+nfoldMap = ncfoldMap (Proxy @Top)

--- a/src/Test/StateMachine/Lockstep/NAry.hs
+++ b/src/Test/StateMachine/Lockstep/NAry.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs               #-}
-{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
@@ -161,7 +160,7 @@ instance All (And ToExpr (Compose ToExpr (MockHandle t))) (RealHandles t)
          . unRefss
     where
       toExprOne :: (ToExpr a, ToExpr (MockHandle t a))
-                => Refs t Concrete a -> K (TD.Expr) a
+                => Refs t Concrete a -> K TD.Expr a
       toExprOne = K . toExpr
 
 instance SListI (RealHandles t) => Semigroup (Refss t r) where
@@ -272,7 +271,7 @@ semantics :: StateMachineTest t m
           -> Cmd t :@ Concrete
           -> m (Resp t :@ Concrete)
 semantics StateMachineTest{..} (At c) =
-    (At . ncfmap (Proxy @Typeable) (const wrapConcrete)) <$>
+    At . ncfmap (Proxy @Typeable) (const wrapConcrete) <$>
       runReal (nfmap (const unwrapConcrete) c)
 
 unwrapConcrete :: FlipRef Concrete a -> I a
@@ -368,7 +367,7 @@ precondition (Model _ (Refss hs)) (At c) =
     Boolean (M.getAll $ nfoldMap check c) .// "No undefined handles"
   where
     check :: Elem (RealHandles t) a -> FlipRef Symbolic a -> M.All
-    check ix (FlipRef a) = M.All $ any (sameRef a) $ map fst (unRefs (hs `npAt` ix))
+    check ix (FlipRef a) = M.All $ any (sameRef a . fst) (unRefs (hs `npAt` ix))
 
     -- TODO: Patch QSM
     sameRef :: Reference a Symbolic -> Reference a Symbolic -> Bool

--- a/src/Test/StateMachine/Lockstep/Simple.hs
+++ b/src/Test/StateMachine/Lockstep/Simple.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE FlexibleInstances         #-}
 {-# LANGUAGE GADTs                     #-}
-{-# LANGUAGE KindSignatures            #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
@@ -142,7 +141,7 @@ cmdAtFromSimple :: Functor (Cmd t) => Cmd t :@ r -> NAry.Cmd (Simple t) NAry.:@ 
 cmdAtFromSimple = NAry.At . SimpleCmd . fmap NAry.FlipRef . unAt
 
 cmdAtToSimple :: Functor (Cmd t) => NAry.Cmd (Simple t) NAry.:@ r -> Cmd t :@ r
-cmdAtToSimple = At . fmap (NAry.unFlipRef) . unSimpleCmd . NAry.unAt
+cmdAtToSimple = At . fmap NAry.unFlipRef . unSimpleCmd . NAry.unAt
 
 cmdMockToSimple :: Functor (Cmd t)
                 => NAry.Cmd (Simple t) (NAry.MockHandle (Simple t)) '[RealHandle t]
@@ -275,7 +274,7 @@ instance ToExpr (MockHandle t)
 fromSimple :: StateMachineTest t -> NAry.StateMachineTest (Simple t) IO
 fromSimple StateMachineTest{..} = NAry.StateMachineTest {
       runMock    = \cmd st -> first respMockFromSimple (runMock (cmdMockToSimple cmd) st)
-    , runReal    = \cmd -> respRealFromSimple <$> (runReal (cmdRealToSimple cmd))
+    , runReal    = \cmd -> respRealFromSimple <$> runReal (cmdRealToSimple cmd)
     , initMock   = initMock
     , newHandles = \r -> Comp (newHandles (unSimpleResp r)) :* Nil
     , generator  = \m     -> fmap cmdAtFromSimple <$> generator (modelToSimple m)

--- a/src/Test/StateMachine/Parallel.hs
+++ b/src/Test/StateMachine/Parallel.hs
@@ -120,6 +120,7 @@ import           Test.StateMachine.Sequential
 import           Test.StateMachine.Types
 import qualified Test.StateMachine.Types.Rank2     as Rank2
 import           Test.StateMachine.Utils
+import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 ------------------------------------------------------------------------
 
@@ -815,11 +816,19 @@ prettyParallelCommandsWithOpts cmds mGraphOptions histories = do
   mapM_ (\(h, _, l) -> printCounterexample h (logic l) `whenFailM` property (boolean l)) histories
     where
       printCounterexample hist' (VFalse ce) = do
-        putStrLn ""
-        print (toBoxDrawings cmds hist')
-        putStrLn ""
-        print (simplify ce)
-        putStrLn ""
+        PP.putDoc $
+          mconcat
+           [ PP.line
+           , PP.string (show $ toBoxDrawings cmds hist')
+           , PP.string (show $ simplify ce)
+           , PP.line
+           , PP.line
+           , PP.string $
+             if or [ boolean l | (_, _, l) <- histories]
+             then "However, some repetitions of this sequence of commands passed. Maybe there is a race condition?"
+             else "And all repetitions of this sequence of commands failed. Maybe there is a logic bug? Try with more repetitions to be sure that it happens consistently"
+           , PP.line
+           ]
         case mGraphOptions of
           Nothing       -> return ()
           Just gOptions -> createAndPrintDot cmds gOptions hist'
@@ -857,9 +866,18 @@ prettyNParallelCommandsWithOpts cmds mGraphOptions histories =
    mapM_ (\(h, _, l) -> printCounterexample h (logic l) `whenFailM` property (boolean l)) histories
     where
       printCounterexample hist' (VFalse ce) = do
-        putStrLn ""
-        print (simplify ce)
-        putStrLn ""
+        PP.putDoc $
+          mconcat
+           [ PP.line
+           , PP.string (show $ simplify ce)
+           , PP.line
+           , PP.line
+           , PP.string $
+             if or [ boolean l | (_, _, l) <- histories]
+             then "However, some repetitions of this sequence of commands passed. Maybe there is a race condition?"
+             else "And all repetitions of this sequence of commands failed. Maybe there is a logic bug? Try with more repetitions to be sure that it happens consistently"
+           , PP.line
+           ]
         case mGraphOptions of
           Nothing       -> return ()
           Just gOptions -> createAndPrintDot cmds gOptions hist'

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveFoldable             #-}
-{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}

--- a/src/Test/StateMachine/Z.hs
+++ b/src/Test/StateMachine/Z.hs
@@ -63,6 +63,8 @@ module Test.StateMachine.Z
   ) where
 
 import qualified Data.List               as L
+import           Data.Maybe
+                   (fromMaybe)
 import           Prelude                 hiding
                    (elem, notElem)
 import qualified Prelude                 as P
@@ -272,7 +274,7 @@ isBijection r xs ys = isTotalInj r xs :&& isTotalSurj r xs ys
 
 -- | Application.
 (!) :: (Eq a, Show a, Show b) => Fun a b -> a -> b
-f ! x = maybe (error msg) Prelude.id (lookup x f)
+f ! x = fromMaybe (error msg) (lookup x f)
   where
     msg = "!: failed to lookup `" ++ show x ++ "' in `" ++ show f ++ "'"
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -32,13 +32,15 @@ import           MemoryReference
 import           Mock
 import           Overflow
 import           ProcessRegistry
-import           RQlite
 import qualified ShrinkingProps
 import           SQLite
 import           Test.StateMachine.Markov
                    (PropertyName, StatsDb, fileStatsDb)
 import           TicketDispenser
 import qualified UnionFind
+
+-- RQlite tests fail, see #14
+import           RQlite
 
 ------------------------------------------------------------------------
 
@@ -218,9 +220,10 @@ tests docker0 = testGroup "Tests"
                                  (\io -> testProperty test (prop (snd <$> io)))
       | otherwise = testCase ("No docker, skipping: " ++ test) (return ())
 
-    whenDocker docker test prop
-      | docker    = prop
-      | otherwise = testCase ("No docker, skipping: " ++ test) (return ())
+    -- Currently unused, see #14
+    -- whenDocker docker test prop
+    --   | docker    = prop
+    --   | otherwise = testCase ("No docker, skipping: " ++ test) (return ())
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
(Note: this is probably easier to review by commits instead of as a whole, due to the HLint and Readme changes)

This PR provides 3 improvements for QSM:
1. Boxes are now printed properly even if there is only a sequential prefix of actions, i.e.

```
┌────────────────────────────────────────────┐
│ [Var 0] ← Create                           │
│    → Created (Reference (Concrete Opaque)) │
└────────────────────────────────────────────┘
┌────────────────────────────────────────────┐
│ [] ← Write (Reference (Concrete Opaque)) 5 │
│                                  → Written │
└────────────────────────────────────────────┘
┌────────────────────────────────────────────┐
│ [] ← Read (Reference (Concrete Opaque))    │
│                              → ReadValue 6 │
└────────────────────────────────────────────┘

versus

┌┐
│ [Var 0] ← Create │
│ → Created (Reference (Concrete Opaque)) │
└┘
┌┐
│ [] ← Write (Reference (Concrete Opaque)) 5 │
│ → Written │
└┘
┌┐
│ [] ← Read (Reference (Concrete Opaque)) │
│ → ReadValue 6 │
└┘
```

2. Exceptions are printed outside of the boxed layout, i.e.

```
Tests
  MemoryReference
    CrashAndLogicBugParallel: 
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│ [Var 0] ← Create                                                                         │
│                                                  → Created (Reference (Concrete Opaque)) │
└──────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│ [] ← Read (Reference (Concrete Opaque))                                                  │
│                                                                            → ReadValue 0 │
└──────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│ Create                                                                                   │
│                                                  → Created (Reference (Concrete Opaque)) │
└──────────────────────────────────────────────────────────────────────────────────────────┘
                                            │ ┌────────────────────────────────────────────┐
                                            │ │ [] ← Write (Reference (Concrete Opaque)) 0 │
┌─────────────────────────────────────────┐ │ │                                            │
│ [] ← Read (Reference (Concrete Opaque)) │ │ │                                            │
│                                         │ │ │                              → Exception 0 │
│                                         │ │ └────────────────────────────────────────────┘
│                           → ReadValue 1 │ │                                               
└─────────────────────────────────────────┘ │                                               
                                            │ │                                  → Written │
                                            │ └────────────────────────────────────────────┘

Exception 0:
  Crash after writing!
  CallStack (from HasCallStack):
    error, called at test/MemoryReference.hs:165:9 in main:MemoryReference

versus

Tests
  MemoryReference
    CrashAndLogicBugParallel: 
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│ [Var 0] ← Create                                                                         │
│                                                  → Created (Reference (Concrete Opaque)) │
└──────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│ [] ← Read (Reference (Concrete Opaque))                                                  │
│                                                                            → ReadValue 0 │
└──────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│ Create                                                                                   │
│                                                  → Created (Reference (Concrete Opaque)) │
└──────────────────────────────────────────────────────────────────────────────────────────┘
                                            │ ┌────────────────────────────────────────────┐
                                            │ │ [] ← Write (Reference (Concrete Opaque)) 0 │
┌─────────────────────────────────────────┐ │ │                                            │
│ [] ← Read (Reference (Concrete Opaque)) │ │ │                                            │
│                                         │ │ │                              → CallStack (from HasCallStack):
    error, called at test/MemoryReference.hs:165:9 in main:MemoryReference │
│                                         │ │ └────────────────────────────────────────────┘
│                           → ReadValue 1 │ │                                               
└─────────────────────────────────────────┘ │                                               
                                            │ │                                  → Written │
                                            │ └────────────────────────────────────────────┘
```

3. There is a suggestion that the cause might be a logic bug or a race condition. See bottom of:

```
Tests
  TicketDispenser
    ParallelWithSharedLock: 
┌──────────────────────────────────┐
│ [] ← Reset                       │
│                        → ResetOk │
└──────────────────────────────────┘
               │ ┌─────────────────┐
               │ │ [] ← TakeTicket │
┌────────────┐ │ │                 │
│ [] ← Reset │ │ │                 │
│            │ │ │   → GotTicket 0 │
│            │ │ └─────────────────┘
│  → ResetOk │ │                    
└────────────┘ │                    

EitherC (PredicateC (Just 0 :/= Just 1)) (PredicateC (Just 0 :/= Just 1))

However, some repetitions of this sequence of commands passed. Maybe there is a race condition?
```