### PR TITLE
Remove the tree-diff dependency.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+((haskell-cabal-mode
+  (eval .
+        (add-hook 'before-save-hook
+                  (lambda () (haskell-mode-buffer-apply-command "cabal-fmt")) nil t))))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### 0.8.0 (???)
 
-* Remove `markov-chain-usage-model` dependency and the related
+* BREAKING CHANGE: Remove `markov-chain-usage-model` dependency and the related
   `Test.StateMachine.Markov` module. The tests of the dependency started
   failing:
   https://github.com/advancedtelematic/markov-chain-usage-model/issues/44 , and
@@ -21,7 +21,14 @@
 
 * Add nix support;
 
-* Add back CI support via GitHub Actions (remove old travis config).
+* Add back CI support via GitHub Actions (remove old travis config);
+
+* Remove the tree-diff dependency, and copy in the relevant bits that we need
+  from the 0.0.2.1 version instead. The reason for this is that after that
+  version the license was changed from BSD to GPL and pinning the dependency to
+  that version doesn't compile with newer GHC versions, by inlining tree-diff we
+  are in control of its dependecy bounds (and can thus make it compile with
+  newer versions of GHC).
 
 #### 0.7.3 (2023-6-1)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Copyright (c) 2017-2023 Stevan Andjelkovic, Daniel Gustafsson, Jacob Stanley,
                         Xia Li-yao, Robert Danitz, Thomas Winant, Edsko de
                         Vries, Momoko Hattori, Kostas Dermentzis, Adam Boniecki,
-                        Javier Sagredo
+                        Javier Sagredo, Oleg Grenrus
 
 All rights reserved.
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -1,23 +1,23 @@
-cabal-version:      3.0
-name:               quickcheck-state-machine
-version:            0.7.3
-synopsis:           Test monadic programs using state machine based models
+cabal-version:   3.0
+name:            quickcheck-state-machine
+version:         0.7.3
+synopsis:        Test monadic programs using state machine based models
 description:
   See README at <https://github.com/stevana/quickcheck-state-machine#readme>
 
-homepage:           https://github.com/stevana/quickcheck-state-machine#readme
-license:            BSD-3-Clause
-license-file:       LICENSE
-author:             Stevan Andjelkovic
-maintainer:         Stevan Andjelkovic <stevan.andjelkovic@strath.ac.uk>
+homepage:        https://github.com/stevana/quickcheck-state-machine#readme
+license:         BSD-3-Clause
+license-file:    LICENSE
+author:          Stevan Andjelkovic
+maintainer:      Stevan Andjelkovic <stevan.andjelkovic@strath.ac.uk>
 copyright:
   Copyright (C) 2017-2018, ATS Advanced Telematic Systems GmbH;
   2018-2019, HERE Europe B.V.;
   2019-2023, Stevan Andjelkovic.
 
-category:           Testing
-build-type:         Simple
-extra-source-files:
+category:        Testing
+build-type:      Simple
+extra-doc-files:
   CHANGELOG.md
   CONTRIBUTING.md
   README.md
@@ -40,6 +40,12 @@ library
     Test.StateMachine.Logic
     Test.StateMachine.Parallel
     Test.StateMachine.Sequential
+    Test.StateMachine.TreeDiff
+    Test.StateMachine.TreeDiff.Class
+    Test.StateMachine.TreeDiff.Expr
+    Test.StateMachine.TreeDiff.List
+    Test.StateMachine.TreeDiff.Pretty
+    Test.StateMachine.TreeDiff.Tree
     Test.StateMachine.Types
     Test.StateMachine.Types.Environment
     Test.StateMachine.Types.GenSym
@@ -50,27 +56,40 @@ library
     Test.StateMachine.Z
 
   other-modules:    Paths_quickcheck_state_machine
+  autogen-modules:  Paths_quickcheck_state_machine
+
+  -- GHC boot library dependencies:
+  -- (https://gitlab.haskell.org/ghc/ghc/-/blob/master/packages)
+  build-depends:
+    , base        >=4.10    && <5
+    , containers  >=0.5.7.1
+    , directory   >=1.0.0.0
+    , exceptions  >=0.8.3
+    , filepath    >=1.0
+    , mtl         >=2.2.1
+    , process     >=1.2.0.0
+    , text        >=1.2.3.1
+    , time        >=1.7
+
   build-depends:
     , ansi-wl-pprint  >=0.6.7.3
-    , base            >=4.10        && <5
-    , containers      >=0.5.7.1
-    , directory       >=1.0.0.0
-    , exceptions      >=0.8.3
-    , filepath        >=1.0
     , generic-data    >=0.3.0.0
     , graphviz        >=2999.20.0.3
-    , matrix          >=0.3.5.0
-    , mtl             >=2.2.1
     , pretty-show     >=1.6.16
-    , process         >=1.2.0.0
     , QuickCheck      >=2.12
     , random          >=1.1
-    , sop-core
-    , split
-    , text
-    , time            >=1.7
-    , tree-diff       >=0.0.2.1
+    , sop-core        >=0.5.0.2
+    , split           >=0.2.3.5
     , unliftio        >=0.2.7.0
+
+  -- tree-diff dependencies:
+  build-depends:
+    , base-compat   >=0.9.3
+    , bytestring    >=0.10.4.0
+    , generics-sop  >=0.3.1.0
+    , MemoTrie      >=0.6.8
+    , pretty        >=1.1.1.1
+    , vector        >=0.12
 
   default-language: Haskell2010
 
@@ -119,7 +138,6 @@ test-suite test
     , tasty-hunit
     , tasty-quickcheck
     , text
-    , tree-diff
     , unliftio
     , unliftio-core
     , vector                    >=0.12.0.1

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -76,8 +76,6 @@ module Test.StateMachine
 
   ) where
 
-import           Data.TreeDiff
-                   (ToExpr, toExpr)
 import           Prelude
                    ()
 
@@ -85,4 +83,6 @@ import           Test.StateMachine.ConstructorName
 import           Test.StateMachine.Logic
 import           Test.StateMachine.Parallel
 import           Test.StateMachine.Sequential
+import           Test.StateMachine.TreeDiff
+                   (ToExpr, toExpr)
 import           Test.StateMachine.Types

--- a/src/Test/StateMachine/Lockstep/NAry.hs
+++ b/src/Test/StateMachine/Lockstep/NAry.hs
@@ -61,17 +61,17 @@ import           GHC.Generics
 import           Prelude
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
-import           Test.StateMachine
-                   hiding (showLabelledExamples, showLabelledExamples')
+import           Test.StateMachine                    hiding
+                   (showLabelledExamples, showLabelledExamples')
 
 import qualified Data.Monoid                          as M
-import qualified Data.TreeDiff                        as TD
 import qualified Test.StateMachine.Labelling          as Label
 import qualified Test.StateMachine.Sequential         as Seq
 import qualified Test.StateMachine.Types              as QSM
 import qualified Test.StateMachine.Types.Rank2        as Rank2
 
 import           Test.StateMachine.Lockstep.Auxiliary
+import qualified Test.StateMachine.TreeDiff           as TD
 
 {-------------------------------------------------------------------------------
   Test type-level parameters

--- a/src/Test/StateMachine/Sequential.hs
+++ b/src/Test/StateMachine/Sequential.hs
@@ -56,11 +56,12 @@ module Test.StateMachine.Sequential
   where
 
 import           Control.Exception
-                   (SomeException, SomeAsyncException (..), displayException,
-                   fromException)
-import           Control.Monad (when)
+                   (SomeAsyncException(..), SomeException,
+                   displayException, fromException)
+import           Control.Monad
+                   (when)
 import           Control.Monad.Catch
-                   (MonadCatch(..), MonadMask (..), catch, ExitCase (..))
+                   (ExitCase(..), MonadCatch(..), MonadMask(..), catch)
 import           Control.Monad.State.Strict
                    (StateT, evalStateT, get, lift, put, runStateT)
 import           Data.Bifunctor
@@ -81,9 +82,7 @@ import           Data.Proxy
                    (Proxy(..))
 import qualified Data.Set                          as S
 import           Data.Time
-                    (defaultTimeLocale, formatTime, getZonedTime)
-import           Data.TreeDiff
-                   (ToExpr, ansiWlBgEditExprCompact, ediff)
+                   (defaultTimeLocale, formatTime, getZonedTime)
 import           Prelude
 import           System.Directory
                    (createDirectoryIfMissing)
@@ -100,20 +99,23 @@ import           Test.QuickCheck.Monadic
                    (PropertyM, run)
 import           Test.QuickCheck.Random
                    (mkQCGen)
+import qualified Text.PrettyPrint.ANSI.Leijen      as PP
 import           Text.PrettyPrint.ANSI.Leijen
                    (Doc)
-import qualified Text.PrettyPrint.ANSI.Leijen      as PP
 import           Text.Show.Pretty
                    (ppShow)
 import           UnliftIO
                    (MonadIO, TChan, atomically, liftIO, newTChanIO,
                    tryReadTChan, writeTChan)
-import           UnliftIO.Exception (throwIO)
+import           UnliftIO.Exception
+                   (throwIO)
 
 import           Test.StateMachine.ConstructorName
 import           Test.StateMachine.Labelling
                    (Event(..), execCmds)
 import           Test.StateMachine.Logic
+import           Test.StateMachine.TreeDiff
+                   (ToExpr, ansiWlBgEditExprCompact, ediff)
 import           Test.StateMachine.Types
 import qualified Test.StateMachine.Types.Rank2     as Rank2
 import           Test.StateMachine.Utils

--- a/src/Test/StateMachine/TreeDiff.hs
+++ b/src/Test/StateMachine/TreeDiff.hs
@@ -1,0 +1,21 @@
+-- | Diffing of (expression) trees.
+--
+-- Diffing arbitrary Haskell data. First we convert values to untyped
+-- haskell-like expression 'Expr' using generically derivable 'ToExpr' class.
+-- Then we can diff two 'Expr' values.
+-- The conversion and diffing is done by 'ediff' function.
+-- See type and function haddocks for an examples.
+--
+-- Interesting modules:
+--
+-- * "Data.TreeDiff.Class" for a 'ToExpr' class and 'ediff' utility.
+--
+module Test.StateMachine.TreeDiff (
+    module Test.StateMachine.TreeDiff.Expr,
+    module Test.StateMachine.TreeDiff.Class,
+    module Test.StateMachine.TreeDiff.Pretty,
+    ) where
+
+import Test.StateMachine.TreeDiff.Expr
+import Test.StateMachine.TreeDiff.Class
+import Test.StateMachine.TreeDiff.Pretty

--- a/src/Test/StateMachine/TreeDiff/Class.hs
+++ b/src/Test/StateMachine/TreeDiff/Class.hs
@@ -1,0 +1,481 @@
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DefaultSignatures   #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | A 'ToExpr' class.
+module Test.StateMachine.TreeDiff.Class (
+    ediff,
+    ediff',
+    ToExpr (..),
+    defaultExprViaShow,
+    -- * SOP
+    sopToExpr,
+    ) where
+
+import Data.Foldable      (toList)
+import Data.Proxy         (Proxy (..))
+import Test.StateMachine.TreeDiff.Expr
+import Data.List.Compat      (uncons)
+import Generics.SOP
+       (All, All2, ConstructorInfo (..), DatatypeInfo (..), FieldInfo (..),
+       I (..), K (..), NP (..), SOP (..), constructorInfo, hcliftA2, hcmap,
+       hcollapse, mapIK)
+import Generics.SOP.GGP   (GCode, GDatatypeInfo, GFrom, gdatatypeInfo, gfrom)
+import GHC.Generics       (Generic)
+
+import qualified Data.Map as Map
+
+-- Instances
+import Control.Applicative   (Const (..), ZipList (..))
+import Data.Fixed            (Fixed, HasResolution)
+import Data.Functor.Identity (Identity (..))
+import Data.Int
+import Data.List.NonEmpty    (NonEmpty (..))
+import Data.Void             (Void)
+import Data.Word
+import Numeric.Natural       (Natural)
+
+import qualified Data.Monoid    as Mon
+import qualified Data.Ratio     as Ratio
+import qualified Data.Semigroup as Semi
+
+-- containers
+import qualified Data.IntMap   as IntMap
+import qualified Data.IntSet   as IntSet
+import qualified Data.Sequence as Seq
+import qualified Data.Set      as Set
+import qualified Data.Tree     as Tree
+
+-- text
+import qualified Data.Text      as T
+import qualified Data.Text.Lazy as LT
+
+-- time
+import qualified Data.Time as Time
+
+-- bytestring
+import qualified Data.ByteString       as BS
+import qualified Data.ByteString.Lazy  as LBS
+-- import qualified Data.ByteString.Short as SBS
+
+-- scientific
+-- import qualified Data.Scientific as Sci
+
+-- uuid-types
+-- import qualified Data.UUID.Types as UUID
+
+-- vector
+import qualified Data.Vector           as V
+import qualified Data.Vector.Primitive as VP
+import qualified Data.Vector.Storable  as VS
+import qualified Data.Vector.Unboxed   as VU
+
+-- tagged
+-- import Data.Tagged (Tagged (..))
+
+-- hashable
+-- import Data.Hashable (Hashed, unhashed)
+
+-- unordered-containers
+-- import qualified Data.HashMap.Strict as HM
+-- import qualified Data.HashSet        as HS
+
+-- aeson
+-- import qualified Data.Aeson as Aeson
+
+-- | Difference between two 'ToExpr' values.
+--
+-- >>> let x = (1, Just 2) :: (Int, Maybe Int)
+-- >>> let y = (1, Nothing)
+-- >>> prettyEditExpr (ediff x y)
+-- _×_ 1 -(Just 2) +Nothing
+--
+-- >>> data Foo = Foo { fooInt :: Either Char Int, fooBool :: [Maybe Bool], fooString :: String } deriving (Eq, Generic)
+-- >>> instance ToExpr Foo
+--
+-- >>> prettyEditExpr $ ediff (Foo (Right 2) [Just True] "fo") (Foo (Right 3) [Just True] "fo")
+-- Foo {fooBool = [Just True], fooInt = Right -2 +3, fooString = "fo"}
+--
+-- >>> prettyEditExpr $ ediff (Foo (Right 42) [Just True, Just False] "old") (Foo (Right 42) [Nothing, Just False, Just True] "new")
+-- Foo
+--   {fooBool = [-Just True, +Nothing, Just False, +Just True],
+--    fooInt = Right 42,
+--    fooString = -"old" +"new"}
+--
+ediff :: ToExpr a => a -> a -> Edit EditExpr
+ediff x y = exprDiff (toExpr x) (toExpr y)
+
+-- | Compare different types.
+--
+-- /Note:/ Use with care as you can end up comparing apples with oranges.
+--
+-- >>> prettyEditExpr $ ediff' ["foo", "bar"] [Just "foo", Nothing]
+-- [-"foo", +Just "foo", -"bar", +Nothing]
+--
+ediff' :: (ToExpr a, ToExpr b) => a -> b -> Edit EditExpr
+ediff' x y = exprDiff (toExpr x) (toExpr y)
+
+-- | 'toExpr' converts a Haskell value into
+-- untyped Haskell-like syntax tree, 'Expr'.
+--
+-- >>> toExpr ((1, Just 2) :: (Int, Maybe Int))
+-- App "_\215_" [App "1" [],App "Just" [App "2" []]]
+--
+class ToExpr a where
+    toExpr :: a -> Expr
+    default toExpr
+        :: (Generic a, All2 ToExpr (GCode a), GFrom a, GDatatypeInfo a)
+        => a -> Expr
+    toExpr x = sopToExpr (gdatatypeInfo (Proxy :: Proxy a)) (gfrom x)
+
+    listToExpr :: [a] -> Expr
+    listToExpr = Lst . map toExpr
+
+instance ToExpr Expr where
+    toExpr = id
+
+-- | An alternative implementation for literal types. We use 'show'
+-- representation of them.
+defaultExprViaShow :: Show a => a -> Expr
+defaultExprViaShow x = App (show x) []
+
+-- | >>> prettyExpr $ sopToExpr (gdatatypeInfo (Proxy :: Proxy String)) (gfrom "foo")
+-- _:_ 'f' "oo"
+sopToExpr :: (All2 ToExpr xss) => DatatypeInfo xss -> SOP I xss -> Expr
+sopToExpr di (SOP xss) = hcollapse $ hcliftA2
+    (Proxy :: Proxy (All ToExpr))
+    (\ci xs -> K (sopNPToExpr isNewtype ci xs))
+    (constructorInfo di)
+    xss
+  where
+    isNewtype = case di of
+        Newtype {} -> True
+        ADT {}     -> False
+
+sopNPToExpr :: All ToExpr xs => Bool -> ConstructorInfo xs -> NP I xs -> Expr
+sopNPToExpr _ (Infix cn _ _) xs = App ("_" ++ cn ++ "_") $ hcollapse $
+    hcmap (Proxy :: Proxy ToExpr) (mapIK toExpr) xs
+sopNPToExpr _ (Constructor cn) xs = App cn $ hcollapse $
+    hcmap (Proxy :: Proxy ToExpr) (mapIK toExpr) xs
+sopNPToExpr True (Record cn _) xs = App cn $ hcollapse $
+    hcmap (Proxy :: Proxy ToExpr) (mapIK toExpr) xs
+sopNPToExpr False (Record cn fi) xs = Rec cn $ Map.fromList $ hcollapse $
+    hcliftA2 (Proxy :: Proxy ToExpr) mk fi xs
+  where
+    mk :: ToExpr x => FieldInfo x -> I x -> K (FieldName, Expr) x
+    mk (FieldInfo fn) (I x) = K (fn, toExpr x)
+
+-------------------------------------------------------------------------------
+-- Instances
+-------------------------------------------------------------------------------
+
+instance ToExpr () where toExpr = defaultExprViaShow
+instance ToExpr Bool where toExpr = defaultExprViaShow
+instance ToExpr Ordering where toExpr = defaultExprViaShow
+
+instance ToExpr Integer where toExpr = defaultExprViaShow
+instance ToExpr Natural where toExpr = defaultExprViaShow
+
+instance ToExpr Float where toExpr = defaultExprViaShow
+instance ToExpr Double where toExpr = defaultExprViaShow
+
+instance ToExpr Int where toExpr = defaultExprViaShow
+instance ToExpr Int8 where toExpr = defaultExprViaShow
+instance ToExpr Int16 where toExpr = defaultExprViaShow
+instance ToExpr Int32 where toExpr = defaultExprViaShow
+instance ToExpr Int64 where toExpr = defaultExprViaShow
+
+instance ToExpr Word where toExpr = defaultExprViaShow
+instance ToExpr Word8 where toExpr = defaultExprViaShow
+instance ToExpr Word16 where toExpr = defaultExprViaShow
+instance ToExpr Word32 where toExpr = defaultExprViaShow
+instance ToExpr Word64 where toExpr = defaultExprViaShow
+
+instance ToExpr (Proxy a) where toExpr = defaultExprViaShow
+
+-- | >>> prettyExpr $ toExpr 'a'
+-- 'a'
+--
+-- >>> prettyExpr $ toExpr "Hello world"
+-- "Hello world"
+--
+-- >>> prettyExpr $ toExpr "Hello\nworld"
+-- concat ["Hello\n", "world"]
+--
+-- >>> traverse_ (print . prettyExpr . toExpr) ["", "\n", "foo", "foo\n", "foo\nbar", "foo\nbar\n"]
+-- ""
+-- "\n"
+-- "foo"
+-- "foo\n"
+-- concat ["foo\n", "bar"]
+-- concat ["foo\n", "bar\n"]
+--
+instance ToExpr Char where
+    toExpr = defaultExprViaShow
+    listToExpr = stringToExpr "concat" . unconcat uncons
+
+stringToExpr
+    :: Show a
+    => String -- ^ name of concat
+    -> [a]
+    -> Expr
+stringToExpr _  []  = App "\"\"" []
+stringToExpr _  [l] = defaultExprViaShow l
+stringToExpr cn ls  = App cn [Lst (map defaultExprViaShow ls)]
+
+-- | Split on '\n'.
+--
+-- prop> \xs -> xs == concat (unconcat uncons xs)
+unconcat :: forall a. (a -> Maybe (Char, a)) -> a -> [String]
+unconcat uncons_ = go where
+    go :: a -> [String]
+    go xs = case span_ xs of
+        ~(ys, zs)
+            | null ys   -> []
+            | otherwise -> ys : go zs
+
+    span_ :: a -> (String, a)
+    span_ xs = case uncons_ xs of
+        Nothing         -> ("", xs)
+        Just ~(x, xs')
+            | x == '\n' -> ("\n", xs')
+            | otherwise -> case span_ xs' of
+            ~(ys, zs) -> (x : ys, zs)
+
+instance ToExpr a => ToExpr (Maybe a) where
+    toExpr Nothing  = App "Nothing" []
+    toExpr (Just x) = App "Just" [toExpr x]
+
+instance (ToExpr a, ToExpr b) => ToExpr (Either a b) where
+    toExpr (Left x)  = App "Left"  [toExpr x]
+    toExpr (Right y) = App "Right" [toExpr y]
+
+instance ToExpr a => ToExpr [a] where
+    toExpr = listToExpr
+
+instance (ToExpr a, ToExpr b) => ToExpr (a, b) where
+    toExpr (a, b) = App "_×_" [toExpr a, toExpr b]
+instance (ToExpr a, ToExpr b, ToExpr c) => ToExpr (a, b, c) where
+    toExpr (a, b, c) = App "_×_×_" [toExpr a, toExpr b, toExpr c]
+instance (ToExpr a, ToExpr b, ToExpr c, ToExpr d) => ToExpr (a, b, c, d) where
+    toExpr (a, b, c, d) = App "_×_×_×_" [toExpr a, toExpr b, toExpr c, toExpr d]
+instance (ToExpr a, ToExpr b, ToExpr c, ToExpr d, ToExpr e) => ToExpr (a, b, c, d, e) where
+    toExpr (a, b, c, d, e) = App "_×_×_×_×_" [toExpr a, toExpr b, toExpr c, toExpr d, toExpr e]
+
+-- | >>> prettyExpr $ toExpr (3 % 12 :: Rational)
+-- _%_ 1 4
+instance (ToExpr a, Integral a) => ToExpr (Ratio.Ratio a) where
+    toExpr r = App "_%_" [ toExpr $ Ratio.numerator r, toExpr $ Ratio.denominator r ]
+instance HasResolution a => ToExpr (Fixed a) where toExpr = defaultExprViaShow
+
+-- | >>> prettyExpr $ toExpr $ Identity 'a'
+-- Identity 'a'
+instance ToExpr a => ToExpr (Identity a) where
+    toExpr (Identity x) = App "Identity" [toExpr x]
+
+instance ToExpr a => ToExpr (Const a b)
+instance ToExpr a => ToExpr (ZipList a)
+
+instance ToExpr a => ToExpr (NonEmpty a) where
+    toExpr (x :| xs) = App "NE.fromList" [toExpr (x : xs)]
+
+instance ToExpr Void where
+    toExpr _ = App "error" [toExpr "Void"]
+
+-------------------------------------------------------------------------------
+-- Monoid/semigroups
+-------------------------------------------------------------------------------
+
+instance ToExpr a => ToExpr (Mon.Dual a) where
+instance ToExpr a => ToExpr (Mon.Sum a) where
+instance ToExpr a => ToExpr (Mon.Product a) where
+instance ToExpr a => ToExpr (Mon.First a) where
+instance ToExpr a => ToExpr (Mon.Last a) where
+
+-- instance ToExpr a => ToExpr (Semi.Option a) where
+instance ToExpr a => ToExpr (Semi.Min a) where
+instance ToExpr a => ToExpr (Semi.Max a) where
+instance ToExpr a => ToExpr (Semi.First a) where
+instance ToExpr a => ToExpr (Semi.Last a) where
+
+-------------------------------------------------------------------------------
+-- containers
+-------------------------------------------------------------------------------
+
+instance ToExpr a => ToExpr (Tree.Tree a) where
+    toExpr (Tree.Node x xs) = App "Node" [toExpr x, toExpr xs]
+
+instance (ToExpr k, ToExpr v) => ToExpr (Map.Map k v) where
+    toExpr x = App "Map.fromList" [ toExpr $ Map.toList x ]
+instance (ToExpr k) => ToExpr (Set.Set k) where
+    toExpr x = App "Set.fromList" [ toExpr $ Set.toList x ]
+instance (ToExpr v) => ToExpr (IntMap.IntMap v) where
+    toExpr x = App "IntMap.fromList" [ toExpr $ IntMap.toList x ]
+instance ToExpr IntSet.IntSet where
+    toExpr x = App "IntSet.fromList" [ toExpr $ IntSet.toList x ]
+instance (ToExpr v) => ToExpr (Seq.Seq v) where
+    toExpr x = App "Seq.fromList" [ toExpr $ toList x ]
+
+-------------------------------------------------------------------------------
+-- text
+-------------------------------------------------------------------------------
+
+-- | >>> traverse_ (print . prettyExpr . toExpr . LT.pack) ["", "\n", "foo", "foo\n", "foo\nbar", "foo\nbar\n"]
+-- ""
+-- "\n"
+-- "foo"
+-- "foo\n"
+-- LT.concat ["foo\n", "bar"]
+-- LT.concat ["foo\n", "bar\n"]
+instance ToExpr LT.Text where
+    toExpr = stringToExpr "LT.concat" . unconcat LT.uncons
+
+-- | >>> traverse_ (print . prettyExpr . toExpr . T.pack) ["", "\n", "foo", "foo\n", "foo\nbar", "foo\nbar\n"]
+-- ""
+-- "\n"
+-- "foo"
+-- "foo\n"
+-- T.concat ["foo\n", "bar"]
+-- T.concat ["foo\n", "bar\n"]
+instance ToExpr T.Text where
+    toExpr = stringToExpr "T.concat" . unconcat T.uncons
+
+-------------------------------------------------------------------------------
+-- time
+-------------------------------------------------------------------------------
+
+-- | >>> prettyExpr $ toExpr $ ModifiedJulianDay 58014
+-- Day "2017-09-18"
+instance ToExpr Time.Day where
+    toExpr d = App "Day" [ toExpr (show d) ]
+
+instance ToExpr Time.UTCTime where
+    toExpr t = App "UTCTime" [ toExpr (show t) ]
+
+-------------------------------------------------------------------------------
+-- bytestring
+-------------------------------------------------------------------------------
+
+-- | >>> traverse_ (print . prettyExpr . toExpr . LBS8.pack) ["", "\n", "foo", "foo\n", "foo\nbar", "foo\nbar\n"]
+-- ""
+-- "\n"
+-- "foo"
+-- "foo\n"
+-- LBS.concat ["foo\n", "bar"]
+-- LBS.concat ["foo\n", "bar\n"]
+instance ToExpr LBS.ByteString where
+    toExpr = stringToExpr "LBS.concat" . bsUnconcat LBS.null LBS.elemIndex LBS.splitAt
+
+-- | >>> traverse_ (print . prettyExpr . toExpr . BS8.pack) ["", "\n", "foo", "foo\n", "foo\nbar", "foo\nbar\n"]
+-- ""
+-- "\n"
+-- "foo"
+-- "foo\n"
+-- BS.concat ["foo\n", "bar"]
+-- BS.concat ["foo\n", "bar\n"]
+instance ToExpr BS.ByteString where
+    toExpr = stringToExpr "BS.concat" . bsUnconcat BS.null BS.elemIndex BS.splitAt
+
+-- | >>> traverse_ (print . prettyExpr . toExpr . SBS.toShort . BS8.pack) ["", "\n", "foo", "foo\n", "foo\nbar", "foo\nbar\n"]
+-- ""
+-- "\n"
+-- "foo"
+-- "foo\n"
+-- mconcat ["foo\n", "bar"]
+-- mconcat ["foo\n", "bar\n"]
+-- instance ToExpr SBS.ShortByteString where
+--     toExpr = stringToExpr "mconcat" . bsUnconcat BS.null BS.elemIndex BS.splitAt . SBS.fromShort
+
+bsUnconcat
+    :: forall bs int. Num int
+    => (bs -> Bool)
+    -> (Word8 -> bs -> Maybe int)
+    -> (int -> bs -> (bs, bs))
+    -> bs
+    -> [bs]
+bsUnconcat null_ elemIndex_ splitAt_ = go where
+    go :: bs -> [bs]
+    go bs
+        | null_ bs  = []
+        | otherwise = case elemIndex_ 10 bs of
+            Nothing -> [bs]
+            Just i  -> case splitAt_ (i + 1) bs of
+                (bs0, bs1) -> bs0 : go bs1
+
+-------------------------------------------------------------------------------
+-- scientific
+-------------------------------------------------------------------------------
+
+-- | >>> prettyExpr $ toExpr (123.456 :: Scientific)
+-- scientific 123456 `-3`
+-- instance ToExpr Sci.Scientific where
+--     toExpr s = App "scientific" [ toExpr $ Sci.coefficient s, toExpr $ Sci.base10Exponent s ]
+
+-------------------------------------------------------------------------------
+-- uuid-types
+-------------------------------------------------------------------------------
+
+-- | >>> prettyExpr $ toExpr UUID.nil
+-- UUID "00000000-0000-0000-0000-000000000000"
+-- instance ToExpr UUID.UUID where
+--     toExpr u = App "UUID" [ toExpr $ UUID.toString u ]
+
+-------------------------------------------------------------------------------
+-- vector
+-------------------------------------------------------------------------------
+
+instance ToExpr a => ToExpr (V.Vector a) where
+    toExpr x = App "V.fromList" [ toExpr $ V.toList x ]
+instance (ToExpr a, VU.Unbox a) => ToExpr (VU.Vector a) where
+    toExpr x = App "VU.fromList" [ toExpr $ VU.toList x ]
+instance (ToExpr a, VS.Storable a) => ToExpr (VS.Vector a) where
+    toExpr x = App "VS.fromList" [ toExpr $ VS.toList x ]
+instance (ToExpr a, VP.Prim a) => ToExpr (VP.Vector a) where
+    toExpr x = App "VP.fromList" [ toExpr $ VP.toList x ]
+
+-------------------------------------------------------------------------------
+-- tagged
+-------------------------------------------------------------------------------
+
+-- instance ToExpr a => ToExpr (Tagged t a) where
+--     toExpr (Tagged x) = App "Tagged" [ toExpr x ]
+
+-------------------------------------------------------------------------------
+-- hashable
+-------------------------------------------------------------------------------
+
+-- instance ToExpr a => ToExpr (Hashed a) where
+--     toExpr x = App "hashed" [ toExpr $ unhashed x ]
+
+-------------------------------------------------------------------------------
+-- unordered-containers
+-------------------------------------------------------------------------------
+
+-- instance (ToExpr k, ToExpr v) => ToExpr (HM.HashMap k v) where
+--     toExpr x = App "HM.fromList" [ toExpr $ HM.toList x ]
+-- instance (ToExpr k) => ToExpr (HS.HashSet k) where
+--     toExpr x = App "HS.fromList" [ toExpr $ HS.toList x ]
+
+-------------------------------------------------------------------------------
+-- aeson
+-------------------------------------------------------------------------------
+
+-- instance ToExpr Aeson.Value
+
+-------------------------------------------------------------------------------
+-- Doctest
+-------------------------------------------------------------------------------
+
+-- $setup
+-- >>> :set -XDeriveGeneric
+-- >>> :set -XDeriveGeneric
+-- >>> import Data.Foldable (traverse_)
+-- >>> import Data.Ratio ((%))
+-- >>> import Data.Time (Day (..))
+-- >>> import Data.Scientific (Scientific)
+-- >>> import Data.TreeDiff.Pretty
+-- >>> import qualified Data.ByteString.Char8 as BS8
+-- >>> import qualified Data.ByteString.Lazy.Char8 as LBS8

--- a/src/Test/StateMachine/TreeDiff/Expr.hs
+++ b/src/Test/StateMachine/TreeDiff/Expr.hs
@@ -1,0 +1,102 @@
+-- | This module uses 'Expr' for richer diffs than based on 'Tree'.
+module Test.StateMachine.TreeDiff.Expr (
+    -- * Types
+    Expr (..),
+    ConstructorName,
+    FieldName,
+    EditExpr (..),
+    Edit (..),
+    exprDiff,
+    ) where
+
+import Prelude ()
+import Prelude.Compat
+
+import Data.Map           (Map)
+import Test.StateMachine.TreeDiff.List
+
+import qualified Data.Map        as Map
+import qualified Test.QuickCheck as QC
+
+-- | Constructor name is a string
+type ConstructorName = String
+--
+-- | Record field name is a string too.
+type FieldName       = String
+
+-- | A untyped Haskell-like expression.
+--
+-- Having richer structure than just 'Tree' allows to have richer diffs.
+data Expr
+    = App ConstructorName [Expr]                 -- ^ application
+    | Rec ConstructorName (Map FieldName Expr)   -- ^ record constructor
+    | Lst [Expr]                                 -- ^ list constructor
+  deriving (Eq, Show)
+
+instance QC.Arbitrary Expr where
+    arbitrary = QC.scale (min 25) $ QC.sized arb where
+        arb n | n <= 0 = QC.oneof
+            [ (`App` []) <$> arbName
+            ,  (`Rec` mempty) <$> arbName
+            ]
+        arb n | otherwise = do
+            n' <- QC.choose (0, n `div` 3)
+            QC.oneof
+                [ App <$> arbName <*> QC.liftArbitrary (arb n')
+                , Rec <$> arbName <*> QC.liftArbitrary (arb n')
+                , Lst <$> QC.liftArbitrary (arb n')
+                ]
+
+    shrink (Lst es)   = es
+        ++ [ Lst es'    | es' <- QC.shrink es ]
+    shrink (Rec n fs) = Map.elems fs
+        ++ [ Rec n' fs  | n'  <- QC.shrink n  ]
+        ++ [ Rec n  fs' | fs' <- QC.shrink fs ]
+    shrink (App n es) = es
+        ++ [ App n' es  | n'  <- QC.shrink n  ]
+        ++ [ App n  es' | es' <- QC.shrink es ]
+
+arbName :: QC.Gen String
+arbName = QC.frequency
+    [ (10, QC.liftArbitrary $ QC.elements $ ['a'..'z'] ++ ['0' .. '9'] ++ "+-_:")
+    , (1, show <$> (QC.arbitrary :: QC.Gen String))
+    , (1, QC.arbitrary)
+    , (1, QC.elements ["_×_", "_×_×_", "_×_×_×_"])
+    ]
+
+-- | Diff two 'Expr'.
+--
+-- For examples see 'ediff' in "Data.TreeDiff.Class".
+exprDiff :: Expr -> Expr -> Edit EditExpr
+exprDiff = impl
+  where
+    impl ea eb | ea == eb = Cpy (EditExp ea)
+
+    impl ea@(App a as) eb@(App b bs)
+        | a == b = Cpy $ EditApp a (map recurse (diffBy (==) as bs))
+        | otherwise = Swp (EditExp ea) (EditExp eb)
+    impl ea@(Rec a as) eb@(Rec b bs)
+        | a == b = Cpy $ EditRec a $ Map.unions [inter, onlyA, onlyB]
+        | otherwise = Swp (EditExp ea) (EditExp eb)
+      where
+        inter = Map.intersectionWith exprDiff as bs
+        onlyA = fmap (Del . EditExp) (Map.difference as inter)
+        onlyB = fmap (Ins . EditExp) (Map.difference bs inter)
+    impl (Lst as) (Lst bs) =
+        Cpy $ EditLst (map recurse (diffBy (==) as bs))
+
+    -- If higher level doesn't match, just swap.
+    impl a b = Swp (EditExp a) (EditExp b)
+
+    recurse (Ins x)   = Ins (EditExp x)
+    recurse (Del y)   = Del (EditExp y)
+    recurse (Cpy z)   = Cpy (EditExp z)
+    recurse (Swp x y) = impl x y
+
+-- | Type used in the result of 'ediff'.
+data EditExpr
+    = EditApp ConstructorName [Edit EditExpr]
+    | EditRec ConstructorName (Map FieldName (Edit EditExpr))
+    | EditLst [Edit EditExpr]
+    | EditExp Expr  -- ^ unchanged tree
+  deriving Show

--- a/src/Test/StateMachine/TreeDiff/List.hs
+++ b/src/Test/StateMachine/TreeDiff/List.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | A list diff.
+module Test.StateMachine.TreeDiff.List (diffBy, Edit (..)) where
+
+import Data.List.Compat (sortOn)
+import qualified Data.MemoTrie as M
+import qualified Data.Vector as V
+
+-- | List edit operations
+--
+-- The 'Swp' constructor is redundant, but it let us spot
+-- a recursion point when performing tree diffs.
+data Edit a
+    = Ins a    -- ^ insert
+    | Del a    -- ^ delete
+    | Cpy a    -- ^ copy unchanged
+    | Swp a a  -- ^ swap, i.e. delete + insert
+  deriving Show
+
+-- | List difference.
+--
+-- >>> diffBy (==) "hello" "world"
+-- [Swp 'h' 'w',Swp 'e' 'o',Swp 'l' 'r',Cpy 'l',Swp 'o' 'd']
+--
+-- >>> diffBy (==) "kitten" "sitting"
+-- [Swp 'k' 's',Cpy 'i',Cpy 't',Cpy 't',Swp 'e' 'i',Cpy 'n',Ins 'g']
+--
+-- prop> \xs ys -> length (diffBy (==) xs ys) >= max (length xs) (length (ys :: String))
+-- prop> \xs ys -> length (diffBy (==) xs ys) <= length xs + length (ys :: String)
+--
+-- /Note:/ currently this has O(n*m) memory requirements, for the sake
+-- of more obviously correct implementation.
+--
+diffBy :: forall a. (a -> a -> Bool) -> [a] -> [a] -> [Edit a]
+diffBy eq xs' ys' = reverse (snd (lcs (V.length xs) (V.length ys)))
+  where
+    xs = V.fromList xs'
+    ys = V.fromList ys'
+
+    lcs = M.memo2 impl
+
+    impl :: Int -> Int -> (Int, [Edit a])
+    impl 0 0 = (0, [])
+    impl 0 m = case lcs 0 (m-1) of
+        (w, edit) -> (w + 1, Ins (ys V.! (m - 1)) : edit)
+    impl n 0 = case lcs (n -1) 0 of
+        (w, edit) -> (w + 1, Del (xs V.! (n - 1)) : edit)
+
+    impl n m = head $ sortOn fst
+        [ edit
+        , bimap (+1) (Ins y :) (lcs n (m - 1))
+        , bimap (+1) (Del x :) (lcs (n - 1) m)
+        ]
+      where
+        x = xs V.! (n - 1)
+        y = ys V.! (m - 1)
+
+        edit
+            | eq x y    = bimap id   (Cpy x :)   (lcs (n - 1) (m - 1))
+            | otherwise = bimap (+1) (Swp x y :) (lcs (n -1 ) (m - 1))
+
+bimap :: (a -> c) -> (b -> d) -> (a, b) -> (c, d)
+bimap f g (x, y) = (f x, g y)

--- a/src/Test/StateMachine/TreeDiff/Pretty.hs
+++ b/src/Test/StateMachine/TreeDiff/Pretty.hs
@@ -1,0 +1,253 @@
+-- | Utilities to pretty print 'Expr' and 'EditExpr'
+module Test.StateMachine.TreeDiff.Pretty (
+    -- * Explicit dictionary
+    Pretty (..),
+    ppExpr,
+    ppEditExpr,
+    ppEditExprCompact,
+    -- * pretty
+    prettyPretty,
+    prettyExpr,
+    prettyEditExpr,
+    prettyEditExprCompact,
+    -- * ansi-wl-pprint
+    ansiWlPretty,
+    ansiWlExpr,
+    ansiWlEditExpr,
+    ansiWlEditExprCompact,
+    -- ** background
+    ansiWlBgPretty,
+    ansiWlBgExpr,
+    ansiWlBgEditExpr,
+    ansiWlBgEditExprCompact,
+    -- * Utilities
+    escapeName,
+    ) where
+
+import Data.Char          (isAlphaNum, isPunctuation, isSymbol, ord)
+import Data.Either        (partitionEithers)
+import Test.StateMachine.TreeDiff.Expr
+import Numeric            (showHex)
+import Text.Read          (readMaybe)
+
+
+import qualified Data.Map                     as Map
+import qualified Text.PrettyPrint             as HJ
+import qualified Text.PrettyPrint.ANSI.Leijen as WL
+
+-- | Because we don't want to commit to single pretty printing library,
+-- we use explicit dictionary.
+data Pretty doc = Pretty
+    { ppCon        :: ConstructorName -> doc
+    , ppRec        :: [(FieldName, doc)] -> doc
+    , ppLst        :: [doc] -> doc
+    , ppCpy        :: doc -> doc
+    , ppIns        :: doc -> doc
+    , ppDel        :: doc -> doc
+    , ppSep        :: [doc] -> doc
+    , ppParens     :: doc -> doc
+    , ppHang       :: doc -> doc -> doc
+    }
+
+-- | Escape field or constructor name
+--
+-- >>> putStrLn $ escapeName "Foo"
+-- Foo
+--
+-- >>> putStrLn $ escapeName "_×_"
+-- _×_
+--
+-- >>> putStrLn $ escapeName "-3"
+-- `-3`
+--
+-- >>> putStrLn $ escapeName "kebab-case"
+-- kebab-case
+--
+-- >>> putStrLn $ escapeName "inner space"
+-- `inner space`
+--
+-- >>> putStrLn $ escapeName $ show "looks like a string"
+-- "looks like a string"
+--
+-- >>> putStrLn $ escapeName $ show "tricky" ++ "   "
+-- `"tricky"   `
+--
+-- >>> putStrLn $ escapeName "[]"
+-- `[]`
+--
+-- >>> putStrLn $ escapeName "_,_"
+-- `_,_`
+--
+escapeName :: String -> String
+escapeName n
+    | null n                      = "``"
+    | isValidString n             = n
+    | all valid' n && headNotMP n = n
+    | otherwise                   = "`" ++ concatMap e n ++ "`"
+  where
+    e '`'               = "\\`"
+    e '\\'              = "\\\\"
+    e ' '               = " "
+    e c | not (valid c) = "\\x" ++ showHex (ord c) ";"
+    e c                 = [c]
+
+    valid c = isAlphaNum c || isSymbol c || isPunctuation c
+    valid' c = valid c && c `notElem` "[](){}`\","
+
+    headNotMP ('-' : _) = False
+    headNotMP ('+' : _) = False
+    headNotMP _         = True
+
+    isValidString s
+        | length s >= 2 && head s == '"' && last s == '"' =
+            case readMaybe s :: Maybe String of
+                Just _ -> True
+                Nothing -> False
+    isValidString _         = False
+
+-- | Pretty print an 'Expr' using explicit pretty-printing dictionary.
+ppExpr :: Pretty doc -> Expr -> doc
+ppExpr p = ppExpr' p False
+
+ppExpr' :: Pretty doc -> Bool -> Expr -> doc
+ppExpr' p = impl where
+    impl _ (App x []) = ppCon p (escapeName x)
+    impl b (App x xs) = ppParens' b $ ppHang p (ppCon p (escapeName x)) $
+        ppSep p $ map (impl True) xs
+    impl _ (Rec x xs) = ppHang p (ppCon p (escapeName x)) $ ppRec p $
+        map ppField' $ Map.toList xs
+    impl _ (Lst xs)   = ppLst p (map (impl False) xs)
+
+    ppField' (n, e) = (escapeName n, impl False e)
+
+    ppParens' True  = ppParens p
+    ppParens' False = id
+
+-- | Pretty print an @'Edit' 'EditExpr'@ using explicit pretty-printing dictionary.
+ppEditExpr :: Pretty doc -> Edit EditExpr -> doc
+ppEditExpr = ppEditExpr' False
+
+-- | Like 'ppEditExpr' but print unchanged parts only shallowly
+ppEditExprCompact :: Pretty doc -> Edit EditExpr -> doc
+ppEditExprCompact = ppEditExpr' True
+
+ppEditExpr' :: Bool -> Pretty doc -> Edit EditExpr -> doc
+ppEditExpr' compact p = ppSep p . ppEdit False
+  where
+    ppEdit b (Cpy (EditExp expr)) = [ ppCpy p $ ppExpr' p b expr ]
+    ppEdit b (Cpy expr) = [ ppEExpr b expr ]
+    ppEdit b (Ins expr) = [ ppIns p (ppEExpr b expr) ]
+    ppEdit b (Del expr) = [ ppDel p (ppEExpr b expr) ]
+    ppEdit b (Swp x y) =
+        [ ppDel p (ppEExpr b x)
+        , ppIns p (ppEExpr b y)
+        ]
+
+    ppEExpr _ (EditApp x []) = ppCon p (escapeName x)
+    ppEExpr b (EditApp x xs) = ppParens' b $ ppHang p (ppCon p (escapeName x)) $
+        ppSep p $ concatMap (ppEdit True) xs
+    ppEExpr _ (EditRec x xs) = ppHang p (ppCon p (escapeName x)) $ ppRec p $
+        justs ++ [ (n, ppCon p "...") | n <- take 1 nothings ]
+      where
+        xs' = map ppField' $ Map.toList xs
+        (nothings, justs) = partitionEithers xs'
+
+    ppEExpr _ (EditLst xs)   = ppLst p (concatMap (ppEdit False) xs)
+    ppEExpr b (EditExp x)    = ppExpr' p b x
+
+    ppField' (n, Cpy (EditExp e)) | compact, not (isScalar e) = Left n
+    ppField' (n, e) = Right (escapeName n, ppSep p $ ppEdit False e)
+
+    ppParens' True  = ppParens p
+    ppParens' False = id
+
+    isScalar (App _ []) = True
+    isScalar _          = False
+
+-------------------------------------------------------------------------------
+-- pretty
+-------------------------------------------------------------------------------
+
+-- | 'Pretty' via @pretty@ library.
+prettyPretty :: Pretty HJ.Doc
+prettyPretty = Pretty
+    { ppCon    = HJ.text
+    , ppRec    = HJ.braces . HJ.sep . HJ.punctuate HJ.comma
+               . map (\(fn, d) -> HJ.text fn HJ.<+> HJ.equals HJ.<+> d)
+    , ppLst    = HJ.brackets . HJ.sep . HJ.punctuate HJ.comma
+    , ppCpy    = id
+    , ppIns    = \d -> HJ.char '+' HJ.<> d
+    , ppDel    = \d -> HJ.char '-' HJ.<> d
+    , ppSep    = HJ.sep
+    , ppParens = HJ.parens
+    , ppHang   = \d1 d2 -> HJ.hang d1 2 d2
+    }
+
+-- | Pretty print 'Expr' using @pretty@.
+--
+-- >>> prettyExpr $ Rec "ex" (Map.fromList [("[]", App "bar" [])])
+-- ex {`[]` = bar}
+prettyExpr :: Expr -> HJ.Doc
+prettyExpr = ppExpr prettyPretty
+
+-- | Pretty print @'Edit' 'EditExpr'@ using @pretty@.
+prettyEditExpr :: Edit EditExpr -> HJ.Doc
+prettyEditExpr = ppEditExpr prettyPretty
+
+-- | Compact 'prettyEditExpr'.
+prettyEditExprCompact :: Edit EditExpr -> HJ.Doc
+prettyEditExprCompact = ppEditExprCompact prettyPretty
+
+-------------------------------------------------------------------------------
+-- ansi-wl-pprint
+-------------------------------------------------------------------------------
+
+-- | 'Pretty' via @ansi-wl-pprint@ library (with colors).
+ansiWlPretty :: Pretty WL.Doc
+ansiWlPretty = Pretty
+    { ppCon    = WL.text
+    , ppRec    = WL.encloseSep WL.lbrace WL.rbrace WL.comma
+               . map (\(fn, d) -> WL.text fn WL.<+> WL.equals WL.</> d)
+    , ppLst    = WL.list
+    , ppCpy    = WL.dullwhite
+    , ppIns    = \d -> WL.green $ WL.plain $ WL.char '+' WL.<> d
+    , ppDel    = \d -> WL.red   $ WL.plain $ WL.char '-' WL.<> d
+    , ppSep    = WL.sep
+    , ppParens = WL.parens
+    , ppHang   = \d1 d2 -> WL.hang 2 (d1 WL.</> d2)
+    }
+
+-- | Pretty print 'Expr' using @ansi-wl-pprint@.
+ansiWlExpr :: Expr -> WL.Doc
+ansiWlExpr = ppExpr ansiWlPretty
+
+-- | Pretty print @'Edit' 'EditExpr'@ using @ansi-wl-pprint@.
+ansiWlEditExpr :: Edit EditExpr -> WL.Doc
+ansiWlEditExpr = ppEditExpr ansiWlPretty
+
+-- | Compact 'ansiWlEditExpr'
+ansiWlEditExprCompact :: Edit EditExpr -> WL.Doc
+ansiWlEditExprCompact = ppEditExprCompact ansiWlPretty
+
+-------------------------------------------------------------------------------
+-- Background
+-------------------------------------------------------------------------------
+
+-- | Like 'ansiWlPretty' but color the background.
+ansiWlBgPretty :: Pretty WL.Doc
+ansiWlBgPretty = ansiWlPretty
+    { ppIns    = \d -> WL.ondullgreen $ WL.white $ WL.plain $ WL.char '+' WL.<> d
+    , ppDel    = \d -> WL.ondullred   $ WL.white $ WL.plain $ WL.char '-' WL.<> d
+    }
+
+-- | Pretty print 'Expr' using @ansi-wl-pprint@.
+ansiWlBgExpr :: Expr -> WL.Doc
+ansiWlBgExpr = ppExpr ansiWlBgPretty
+
+-- | Pretty print @'Edit' 'EditExpr'@ using @ansi-wl-pprint@.
+ansiWlBgEditExpr :: Edit EditExpr -> WL.Doc
+ansiWlBgEditExpr = ppEditExpr ansiWlBgPretty
+
+-- | Compact 'ansiWlBgEditExpr'.
+ansiWlBgEditExprCompact :: Edit EditExpr -> WL.Doc
+ansiWlBgEditExprCompact = ppEditExprCompact ansiWlBgPretty

--- a/src/Test/StateMachine/TreeDiff/Tree.hs
+++ b/src/Test/StateMachine/TreeDiff/Tree.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE CPP #-}
+-- | Tree diffing working on @containers@ 'Tree'.
+module Test.StateMachine.TreeDiff.Tree (treeDiff, EditTree (..), Edit (..)) where
+
+import Data.Tree          (Tree (..))
+import Test.StateMachine.TreeDiff.List
+
+#ifdef __DOCTEST__
+import qualified Text.PrettyPrint as PP
+#endif
+
+-- | A breadth-traversal diff.
+--
+-- It's different from @gdiff@, as it doesn't produce a flat edit script,
+-- but edit script iself is a tree. This makes visualising the diff much
+-- simpler.
+--
+-- ==== Examples
+--
+-- Let's start from simple tree. We pretty print them as s-expressions.
+--
+-- >>> let x = Node 'a' [Node 'b' [], Node 'c' [return 'd', return 'e'], Node 'f' []]
+-- >>> ppTree PP.char x
+-- (a b (c d e) f)
+--
+-- If we modify an argument in a tree, we'll notice it's changed:
+--
+-- >>> let y = Node 'a' [Node 'b' [], Node 'c' [return 'x', return 'e'], Node 'f' []]
+-- >>> ppTree PP.char y
+-- (a b (c x e) f)
+--
+-- >>> ppEditTree PP.char (treeDiff x y)
+-- (a b (c -d +x e) f)
+--
+-- If we modify a constructor, the whole sub-trees is replaced, though there
+-- might be common subtrees.
+--
+-- >>> let z = Node 'a' [Node 'b' [], Node 'd' [], Node 'f' []]
+-- >>> ppTree PP.char z
+-- (a b d f)
+--
+-- >>> ppEditTree PP.char (treeDiff x z)
+-- (a b -(c d e) +d f)
+--
+-- If we add arguments, they are spotted too:
+--
+-- >>> let w = Node 'a' [Node 'b' [], Node 'c' [return 'd', return 'x', return 'e'], Node 'f' []]
+-- >>> ppTree PP.char w
+-- (a b (c d x e) f)
+--
+-- >>> ppEditTree PP.char (treeDiff x w)
+-- (a b (c d +x e) f)
+--
+treeDiff :: Eq a => Tree a -> Tree a -> Edit (EditTree a)
+treeDiff ta@(Node a as) tb@(Node b bs)
+    | a == b = Cpy $ EditNode a (map rec (diffBy (==) as bs))
+    | otherwise = Swp (treeToEdit ta) (treeToEdit tb)
+  where
+    rec (Ins x)   = Ins (treeToEdit x)
+    rec (Del y)   = Del (treeToEdit y)
+    rec (Cpy z)   = Cpy (treeToEdit z)
+    rec (Swp x y) = treeDiff x y
+
+-- | Type used in the result of 'treeDiff'.
+--
+-- It's essentially a 'Tree', but the forest list is changed from
+-- @[tree a]@ to @['Edit' (tree a)]@. This highlights that
+-- 'treeDiff' performs a list diff on each tree level.
+data EditTree a
+    = EditNode a [Edit (EditTree a)]
+  deriving Show
+
+treeToEdit :: Tree a -> EditTree a
+treeToEdit = go where go (Node x xs) = EditNode x (map (Cpy . go) xs)
+
+#ifdef __DOCTEST__
+ppTree :: (a -> PP.Doc) -> Tree a -> PP.Doc
+ppTree pp = ppT
+  where
+    ppT (Node x []) = pp x
+    ppT (Node x xs) = PP.parens $ PP.hang (pp x) 2 $
+        PP.sep $ map ppT xs
+
+ppEditTree :: (a -> PP.Doc) -> Edit (EditTree a) -> PP.Doc
+ppEditTree pp = PP.sep . ppEdit
+  where
+    ppEdit (Cpy tree) = [ ppTree tree ]
+    ppEdit (Ins tree) = [ PP.char '+' PP.<> ppTree tree ]
+    ppEdit (Del tree) = [ PP.char '-' PP.<> ppTree tree ]
+    ppEdit (Swp a b) =
+        [ PP.char '-' PP.<> ppTree a
+        , PP.char '+' PP.<> ppTree b
+        ]
+
+    ppTree (EditNode x []) = pp x
+    ppTree (EditNode x xs) = PP.parens $ PP.hang (pp x) 2 $
+       PP.sep $ concatMap ppEdit xs
+#endif

--- a/src/Test/StateMachine/Types/References.hs
+++ b/src/Test/StateMachine/Types/References.hs
@@ -37,14 +37,14 @@ module Test.StateMachine.Types.References
 import           Data.Functor.Classes
                    (Eq1, Ord1, Show1, compare1, eq1, liftCompare,
                    liftEq, liftShowsPrec, showsPrec1)
-import           Data.TreeDiff
-                   (Expr(App), ToExpr, toExpr)
 import           Data.Typeable
                    (Typeable)
 import           GHC.Generics
                    (Generic)
 import           Prelude
 
+import           Test.StateMachine.TreeDiff
+                   (Expr(App), ToExpr, toExpr)
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -89,8 +89,6 @@ import           Data.String.Conversions
 import           Data.Text
                    (Text)
 import qualified Data.Text                     as T
-import           Data.TreeDiff
-                   (Expr(App))
 import           Database.Persist.Class
 import           Database.Persist.Postgresql
                    (ConnectionPool, ConnectionString, SqlBackend,
@@ -111,8 +109,8 @@ import           Network.Socket
 import qualified Network.Wai.Handler.Warp      as Warp
 import           Prelude
 import           Servant
-                   ((:<|>)(..), (:>), Application, Capture, Delete,
-                   Get, JSON, Post, Put, ReqBody, Server, serve)
+                   (Application, Capture, Delete, Get, JSON, Post, Put,
+                   ReqBody, Server, serve, (:<|>)(..), (:>))
 import           Servant.Client
                    (BaseUrl(..), ClientEnv(..), ClientM, Scheme(Http),
                    client, mkClientEnv, runClientM)
@@ -132,6 +130,8 @@ import           UnliftIO
                    (Async, MonadIO, async, cancel, liftIO, waitEither)
 
 import           Test.StateMachine
+import           Test.StateMachine.TreeDiff
+                   (Expr(App))
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------

--- a/test/Hanoi.hs
+++ b/test/Hanoi.hs
@@ -32,8 +32,6 @@ import           Data.Array
 import           Data.Kind
                    (Type)
 import           Data.Maybe
-import           Data.TreeDiff.Expr
-                   ()
 import           GHC.Generics
                    (Generic, Generic1)
 import           Prelude
@@ -44,7 +42,9 @@ import           Test.QuickCheck.Monadic
                    (monadicIO)
 
 import           Test.StateMachine
-import qualified Test.StateMachine.Types.Rank2 as Rank2
+import           Test.StateMachine.TreeDiff.Expr
+                   ()
+import qualified Test.StateMachine.Types.Rank2   as Rank2
 
 ------------------------------------------------------------------------
 

--- a/test/SQLite.hs
+++ b/test/SQLite.hs
@@ -34,7 +34,7 @@ import           Control.Monad.Logger
 import           Control.Monad.Reader
 import           Data.Bifoldable
 import           Data.Bifunctor
-import qualified Data.Bifunctor.TH             as TH
+import qualified Data.Bifunctor.TH               as TH
 import           Data.Bitraversable
 import           Data.Functor.Classes
 import           Data.Kind
@@ -44,10 +44,9 @@ import           Data.Maybe
 import           Data.Pool
 import           Data.Text
                    (Text, pack)
-import           Data.TreeDiff.Expr
 import           Database.Persist
 import           Database.Persist.Sqlite
-import           Database.Sqlite               hiding
+import           Database.Sqlite                 hiding
                    (step)
 import           GHC.Generics
                    (Generic, Generic1)
@@ -57,8 +56,9 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
 import           Test.StateMachine
 import           Test.StateMachine.DotDrawing
+import           Test.StateMachine.TreeDiff.Expr
 import           Test.StateMachine.Types
-import qualified Test.StateMachine.Types.Rank2 as Rank2
+import qualified Test.StateMachine.Types.Rank2   as Rank2
 
 import           Schema
 

--- a/test/ShrinkingProps.hs
+++ b/test/ShrinkingProps.hs
@@ -45,8 +45,6 @@ import           Data.Proxy
 import           Data.Set
                    (Set)
 import qualified Data.Set                      as Set
-import           Data.TreeDiff
-                   (defaultExprViaShow)
 import           Data.Typeable
                    (Typeable)
 import           GHC.Generics
@@ -67,11 +65,13 @@ import           Test.Tasty.QuickCheck
 import           Test.StateMachine
 import qualified Test.StateMachine.Parallel    as QSM
 import qualified Test.StateMachine.Sequential  as QSM
+import           Test.StateMachine.TreeDiff
+                   (defaultExprViaShow)
 import qualified Test.StateMachine.Types       as QSM
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.StateMachine.Utils
-                   (Shrunk(..), shrinkListS', shrinkListS',
-                   shrinkListS'', shrinkPairS')
+                   (Shrunk(..), shrinkListS', shrinkListS'',
+                   shrinkPairS')
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
Vendor/copy in the relevant bits that we need from the 0.0.2.1 version instead. The reason for this is that after that version the license was changed from BSD to GPL and pinning the dependency to that version doesn't compile with newer GHC versions, by inlining tree-diff we are in control of its dependecy bounds (and can thus make it compile with newer versions of GHC).