### PR TITLE
Split vendored tree-diff into a sublibrary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+#### 0.9.0 (????-??-??)
+
+* Split the package into the machinery that abstracts over whichever diffing
+  implementation is in use (via the `CanDiff` class), and the implementation of
+  that class via the vendored tree-diff. See the
+  [README](https://github.com/stevana/quickcheck-state-machine#using-quickcheck-state-machine-as-a-dependency)
+  for more details on how to depend on either.
+
 #### 0.8.0 (2023-11-17)
 
 * BREAKING CHANGE: Remove `markov-chain-usage-model` dependency and the related

--- a/README.md
+++ b/README.md
@@ -667,6 +667,43 @@ More examples from the "real world":
     [tests](https://github.com/stevana/raft/blob/master/test/QuickCheckStateMachine.hs)
     combined with fault injection (node and network failures).
 
+### Using `quickcheck-state-machine` as a dependency
+
+In order to bring `quickcheck-state-machine` into your code, add it to the
+`build-depends` section in your cabal file:
+
+``` cabal
+test-suite ...
+  build-depends:
+    , quickcheck-state-machine
+```
+
+This dependency can be used out of the box, however, it comes with an fork of an
+old version of
+[`tree-diff`](https://hackage.haskell.org/package/tree-diff-0.0.2.1) vendored
+inside.
+
+> For `quickcheck-state-machine` to remain BSD-style licensed, it could not
+> depend on the `tree-diff` package as that one changed its license to `GPL`,
+> therefore the solution was to vendor an older BSD-style licensed version of
+> it. Using this vendored version, your code regardless of whether it is testing
+> code or not, can remain BSD-style licensed.
+
+In case you want to make use of the upstream `tree-diff` package, you can depend
+on a slightly different library name:
+
+``` cabal
+test-suite ...
+  build-depends:
+    , quickcheck-state-machine:no-vendored-treediff
+```
+
+For this to compile properly, you will have to provide your own machinery to
+implement the `CanDiff` class with the upstream `tree-diff` definitions. You
+will have to implement something very similar to [this
+module](./tree-diff/Test/StateMachine/TreeDiff/Diffing.hs) (which is doing
+exactly this but with an old `tree-diff` version).
+
 ### How to contribute
 
 The `quickcheck-state-machine` library is still very experimental.

--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -24,13 +24,20 @@ extra-doc-files:
 
 tested-with:     GHC ==8.8.4 || ==8.10.7 || ==9.2.8 || ==9.4.7 || ==9.6.3
 
-library
+-- Due to `tree-diff` being `GPL`, this library makes use of an interface
+-- (@CanDiff@) to diff models. This can be implemented with the vendored
+-- tree-diff or with the upstream one, but we only provide the former in the
+-- main library of the package below. See
+-- https://github.com/stevana/quickcheck-state-machine#readme for how to depend
+-- on either version.
+library no-vendored-treediff
   hs-source-dirs:   src
   ghc-options:      -Wall
   exposed-modules:
     Test.StateMachine
     Test.StateMachine.BoxDrawer
     Test.StateMachine.ConstructorName
+    Test.StateMachine.Diffing
     Test.StateMachine.DotDrawing
     Test.StateMachine.Labelling
     Test.StateMachine.Lockstep.Auxiliary
@@ -39,12 +46,6 @@ library
     Test.StateMachine.Logic
     Test.StateMachine.Parallel
     Test.StateMachine.Sequential
-    Test.StateMachine.TreeDiff
-    Test.StateMachine.TreeDiff.Class
-    Test.StateMachine.TreeDiff.Expr
-    Test.StateMachine.TreeDiff.List
-    Test.StateMachine.TreeDiff.Pretty
-    Test.StateMachine.TreeDiff.Tree
     Test.StateMachine.Types
     Test.StateMachine.Types.Environment
     Test.StateMachine.Types.GenSym
@@ -53,9 +54,6 @@ library
     Test.StateMachine.Types.References
     Test.StateMachine.Utils
     Test.StateMachine.Z
-
-  other-modules:    Paths_quickcheck_state_machine
-  autogen-modules:  Paths_quickcheck_state_machine
 
   -- GHC boot library dependencies:
   -- (https://gitlab.haskell.org/ghc/ghc/-/blob/master/packages)
@@ -66,13 +64,11 @@ library
     , exceptions  >=0.8.3   && <0.11
     , filepath    >=1.0     && <1.5
     , mtl         >=2.2.1   && <2.4
-    , process     >=1.2.0.0 && <1.7
     , text        >=1.2.3.1 && <2.1
     , time        >=1.7     && <1.13
 
   build-depends:
     , ansi-wl-pprint  >=0.6.7.3     && <1.1
-    , generic-data    >=0.3.0.0     && <1.2
     , graphviz        >=2999.20.0.3 && <2999.21
     , pretty-show     >=1.6.16      && <1.11
     , QuickCheck      >=2.12        && <2.15
@@ -81,23 +77,72 @@ library
     , split           >=0.2.3.5     && <0.3
     , unliftio        >=0.2.7.0     && <0.3
 
+  default-language: Haskell2010
+
+library
+  hs-source-dirs:     tree-diff
+  ghc-options:        -Wall
+  exposed-modules:
+    Test.StateMachine.TreeDiff
+    Test.StateMachine.TreeDiff.Class
+    Test.StateMachine.TreeDiff.Diffing
+    Test.StateMachine.TreeDiff.Expr
+    Test.StateMachine.TreeDiff.List
+    Test.StateMachine.TreeDiff.Pretty
+    Test.StateMachine.TreeDiff.Tree
+
+  reexported-modules:
+    Test.StateMachine,
+    Test.StateMachine.BoxDrawer,
+    Test.StateMachine.ConstructorName,
+    Test.StateMachine.Diffing,
+    Test.StateMachine.DotDrawing,
+    Test.StateMachine.Labelling,
+    Test.StateMachine.Lockstep.Auxiliary,
+    Test.StateMachine.Lockstep.NAry,
+    Test.StateMachine.Lockstep.Simple,
+    Test.StateMachine.Logic,
+    Test.StateMachine.Parallel,
+    Test.StateMachine.Sequential,
+    Test.StateMachine.Types,
+    Test.StateMachine.Types.Environment,
+    Test.StateMachine.Types.GenSym,
+    Test.StateMachine.Types.History,
+    Test.StateMachine.Types.Rank2,
+    Test.StateMachine.Types.References,
+    Test.StateMachine.Utils,
+    Test.StateMachine.Z
+
+  -- GHC boot library dependencies:
+  -- (https://gitlab.haskell.org/ghc/ghc/-/blob/master/packages)
+  build-depends:
+    , base
+    , containers
+    , text
+    , time
+
+  build-depends:
+    , ansi-wl-pprint
+    , QuickCheck
+    , sop-core
+
   -- tree-diff dependencies:
   build-depends:
-    , base-compat   >=0.9.3    && <0.14
-    , bytestring    >=0.10.4.0 && <0.12
-    , generics-sop  >=0.3.1.0  && <0.6
-    , MemoTrie      >=0.6.8    && <0.7
-    , pretty        >=1.1.1.1  && <1.2
-    , vector        >=0.12.0.1 && <0.14
+    , base-compat                                    >=0.9.3    && <0.14
+    , bytestring                                     >=0.10.4.0 && <0.12
+    , generics-sop                                   >=0.3.1.0  && <0.6
+    , MemoTrie                                       >=0.6.8    && <0.7
+    , pretty                                         >=1.1.1.1  && <1.2
+    , quickcheck-state-machine:no-vendored-treediff
+    , vector                                         >=0.12.0.1 && <0.14
 
-  default-language: Haskell2010
+  default-language:   Haskell2010
 
 test-suite test
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Spec.hs
   build-depends:
-    , aeson                     >=1.4.6.0  && <2.3
     , array                     >=0.5.4.0  && <0.6
     , base
     , bifunctors                >=5.5.7    && <5.7
@@ -116,7 +161,6 @@ test-suite test
     , persistent                >=2.10.5.2 && <2.15
     , persistent-postgresql     >=2.10.1.2 && <2.14
     , persistent-sqlite         >=2.10.6.2 && <2.14
-    , persistent-template       >=2.8.2.3  && <2.13
     , postgresql-simple         >=0.6.2    && <0.8
     , pretty-show
     , process
@@ -126,7 +170,6 @@ test-suite test
     , random
     , resource-pool             >=0.2.3.2  && <0.5
     , resourcet                 >=1.2.3    && <1.4
-    , servant                   >=0.16.2   && <0.21
     , servant-client            >=0.16.0.1 && <0.21
     , servant-server            >=0.16.2   && <0.21
     , split                     >=0.2.3.5  && <0.3
@@ -140,7 +183,6 @@ test-suite test
     , unliftio
     , unliftio-core             >=0.1.2.0  && <0.3
     , vector
-    , wai                       >=3.2.2.1  && <3.3
     , warp                      >=3.3.9    && <3.4
 
   other-modules:

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -70,19 +70,16 @@ module Test.StateMachine
 
   , module Test.StateMachine.Logic
 
-    -- * Re-export
-  , ToExpr
-  , toExpr
-
+  -- * Diffing class
+  , CanDiff (..)
   ) where
 
 import           Prelude
                    ()
 
 import           Test.StateMachine.ConstructorName
+import           Test.StateMachine.Diffing
 import           Test.StateMachine.Logic
 import           Test.StateMachine.Parallel
 import           Test.StateMachine.Sequential
-import           Test.StateMachine.TreeDiff
-                   (ToExpr, toExpr)
 import           Test.StateMachine.Types

--- a/src/Test/StateMachine/Diffing.hs
+++ b/src/Test/StateMachine/Diffing.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UndecidableInstances   #-}
+
+-- | Class that will be used when diffing values. It ought to be instantiated
+-- with our vendored @tree-diff@ (see "Test.StateMachine.Diffing.TreeDiff"), or
+-- other akin implementations.
+
+module Test.StateMachine.Diffing (CanDiff(..), ediff) where
+
+import           Data.Proxy
+                   (Proxy(..))
+import qualified Text.PrettyPrint.ANSI.Leijen as WL
+
+class CanDiff x where
+  -- | Expressions that will be diffed
+  type AnExpr x
+  -- | What will the diff of two @AnExpr@s result in
+  type ADiff x
+
+  -- | Extract the expression from the data
+  toDiff :: x -> AnExpr x
+
+  -- | Diff two expressions
+  exprDiff :: Proxy x -> AnExpr x -> AnExpr x -> ADiff x
+
+  -- | Output a diff in compact form
+  diffToDocCompact :: Proxy x -> ADiff x -> WL.Doc
+
+  -- | Output a diff
+  diffToDoc :: Proxy x -> ADiff x -> WL.Doc
+
+  -- | Output an expression
+  exprToDoc :: Proxy x -> AnExpr x -> WL.Doc
+
+ediff :: forall x. CanDiff x => x -> x -> ADiff x
+ediff x y = exprDiff (Proxy @x) (toDiff x) (toDiff y)

--- a/src/Test/StateMachine/Types/References.hs
+++ b/src/Test/StateMachine/Types/References.hs
@@ -43,15 +43,12 @@ import           GHC.Generics
                    (Generic)
 import           Prelude
 
-import           Test.StateMachine.TreeDiff
-                   (Expr(App), ToExpr, toExpr)
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------
 
 newtype Var = Var Int
   deriving stock   (Eq, Ord, Show, Generic, Read)
-  deriving newtype (ToExpr)
 
 data Symbolic a where
   Symbolic :: Typeable a => Var -> Symbolic a
@@ -68,9 +65,6 @@ instance Show1 Symbolic where
       showsPrec (appPrec + 1) x
     where
       appPrec = 10
-
-instance ToExpr a => ToExpr (Symbolic a) where
-  toExpr (Symbolic x) = toExpr x
 
 instance Eq1 Symbolic where
   liftEq _ (Symbolic x) (Symbolic y) = x == y
@@ -101,15 +95,10 @@ deriving instance Ord a => Ord (Concrete a)
 instance Ord1 Concrete where
   liftCompare comp (Concrete x) (Concrete y) = comp x y
 
-instance ToExpr a => ToExpr (Concrete a) where
-  toExpr (Concrete x) = toExpr x
-
 newtype Reference a r = Reference (r a)
   deriving stock Generic
 
 deriving stock instance Typeable a => Read (Reference a Symbolic)
-
-instance ToExpr (r a) => ToExpr (Reference a r)
 
 instance Rank2.Functor (Reference a) where
   fmap f (Reference r) = Reference (f r)
@@ -148,6 +137,3 @@ newtype Opaque a = Opaque
 
 instance Show (Opaque a) where
   showsPrec _ (Opaque _) = showString "Opaque"
-
-instance ToExpr (Opaque a) where
-  toExpr _ = App "Opaque" []

--- a/test/Bookstore.hs
+++ b/test/Bookstore.hs
@@ -58,6 +58,7 @@ import           UnliftIO
                    throwIO)
 
 import           Test.StateMachine
+import           Test.StateMachine.TreeDiff
 import qualified Test.StateMachine.Types.Rank2      as Rank2
 import           Test.StateMachine.Z
                    (codomain, domain)
@@ -143,12 +144,12 @@ findByAuthor, findByTitle
   :: Bug -> String -> Connection -> IO (Maybe [Book])
 findByAuthor bug s = case bug of
   Injection -> handleViolations (select templ $ "%"++s++"%")
-  _          -> handleViolations (select templ $ "%"++(sanitize s)++"%")
+  _         -> handleViolations (select templ $ "%"++(sanitize s)++"%")
   where templ = "SELECT * FROM books WHERE author LIKE ?"
 
 findByTitle bug s = case bug of
   Injection -> handleViolations (select templ $ "%"++s++"%")
-  _          -> handleViolations (select templ $ "%"++(sanitize s)++"%")
+  _         -> handleViolations (select templ $ "%"++(sanitize s)++"%")
   where templ = "SELECT * FROM books WHERE title LIKE ?"
 
 findByIsbn :: String -> Connection -> IO (Maybe [Book])
@@ -347,10 +348,10 @@ postconditions (Model m) cmd resp = case cmd of
 transitions :: Model r -> Command r -> Response r -> Model r
 transitions (Model m) cmd _ = Model $ case cmd of
   NewBook New key t a -> (key, Book (getString key) t a 0 0):m
-  AddCopy Exist key -> map (applyForKey key $ incOwned . incAvail) m
-  Borrow  Avail key -> map (applyForKey key decAvail) m
-  Return  Taken key -> map (applyForKey key incAvail) m
-  _ -> m
+  AddCopy Exist key   -> map (applyForKey key $ incOwned . incAvail) m
+  Borrow  Avail key   -> map (applyForKey key decAvail) m
+  Return  Taken key   -> map (applyForKey key incAvail) m
+  _                   -> m
   where
     applyForKey key fn (k, v) = (k, if k == key then fn v else v)
     incOwned row = row { owned = 1 + owned row }

--- a/test/CircularBuffer.hs
+++ b/test/CircularBuffer.hs
@@ -61,6 +61,7 @@ import           Test.QuickCheck.Monadic
                    (monadicIO)
 
 import           Test.StateMachine
+import           Test.StateMachine.TreeDiff
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------

--- a/test/Cleanup.hs
+++ b/test/Cleanup.hs
@@ -41,7 +41,9 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
                    (monadicIO)
 import           Test.StateMachine
-import qualified Test.StateMachine.Types as QSM (initModel)
+import           Test.StateMachine.TreeDiff
+import qualified Test.StateMachine.Types       as QSM
+                   (initModel)
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.StateMachine.Utils
                    (liftProperty, mkModel, whenFailM)

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -131,7 +131,7 @@ import           UnliftIO
 
 import           Test.StateMachine
 import           Test.StateMachine.TreeDiff
-                   (Expr(App))
+                   (Expr(App), ToExpr(toExpr))
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------

--- a/test/DieHard.hs
+++ b/test/DieHard.hs
@@ -41,6 +41,7 @@ import           Test.QuickCheck.Monadic
                    (monadicIO)
 
 import           Test.StateMachine
+import           Test.StateMachine.TreeDiff
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -39,7 +39,8 @@ import           UnliftIO
                    (TVar, atomically, newTVarIO, readTVar, writeTVar)
 
 import           Test.StateMachine
-import           Test.StateMachine.Types as QC
+import           Test.StateMachine.TreeDiff
+import           Test.StateMachine.Types       as QC
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------

--- a/test/ErrorEncountered.hs
+++ b/test/ErrorEncountered.hs
@@ -26,6 +26,7 @@ import           Test.QuickCheck.Monadic
                    (monadicIO)
 
 import           Test.StateMachine
+import           Test.StateMachine.TreeDiff
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.StateMachine.Z
 

--- a/test/Hanoi.hs
+++ b/test/Hanoi.hs
@@ -42,6 +42,7 @@ import           Test.QuickCheck.Monadic
                    (monadicIO)
 
 import           Test.StateMachine
+import           Test.StateMachine.TreeDiff
 import           Test.StateMachine.TreeDiff.Expr
                    ()
 import qualified Test.StateMachine.Types.Rank2   as Rank2

--- a/test/IORefs.hs
+++ b/test/IORefs.hs
@@ -29,6 +29,7 @@ import           Test.StateMachine
 import qualified Data.Map.Strict                   as Map
 
 import           Test.StateMachine.Lockstep.Simple
+import           Test.StateMachine.TreeDiff
 
 {-------------------------------------------------------------------------------
   Instantiate the simple API

--- a/test/MemoryReference.hs
+++ b/test/MemoryReference.hs
@@ -38,8 +38,8 @@ import           Prelude
 import           System.Random
                    (randomIO, randomRIO)
 import           Test.QuickCheck
-                   (Gen, Property, arbitrary, elements, frequency,
-                   once, shrink, (===))
+                   (Gen, Property, arbitrary, elements, frequency, once,
+                   shrink, (===))
 import           Test.QuickCheck.Monadic
                    (monadicIO)
 
@@ -50,14 +50,15 @@ import           Test.StateMachine.Parallel
                    shrinkNParallelCommands, shrinkParallelCommands)
 import           Test.StateMachine.Sequential
                    (ShouldShrink(..))
+import           Test.StateMachine.TreeDiff
+import qualified Test.StateMachine.Types       as Types
 import           Test.StateMachine.Types
                    (Commands(Commands), Reference(..), Symbolic(..),
                    Var(Var))
-import qualified Test.StateMachine.Types       as Types
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.StateMachine.Utils
-                   (Shrunk(..), shrinkListS, shrinkListS'',
-                   shrinkPairS, shrinkPairS')
+                   (Shrunk(..), shrinkListS, shrinkListS'', shrinkPairS,
+                   shrinkPairS')
 import           Test.StateMachine.Z
 
 ------------------------------------------------------------------------

--- a/test/Mock.hs
+++ b/test/Mock.hs
@@ -27,6 +27,7 @@ import           Test.QuickCheck.Monadic
                    (monadicIO)
 import           Test.StateMachine
 import           Test.StateMachine.DotDrawing
+import           Test.StateMachine.TreeDiff
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------

--- a/test/Overflow.hs
+++ b/test/Overflow.hs
@@ -32,6 +32,7 @@ import           Test.QuickCheck.Monadic
                    (monadicIO)
 import           Test.StateMachine
 import           Test.StateMachine.DotDrawing
+import           Test.StateMachine.TreeDiff
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------

--- a/test/ProcessRegistry.hs
+++ b/test/ProcessRegistry.hs
@@ -80,6 +80,7 @@ import           Test.QuickCheck.Monadic
 
 import           Test.StateMachine
 import           Test.StateMachine.Labelling
+import           Test.StateMachine.TreeDiff
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 

--- a/test/SQLite.hs
+++ b/test/SQLite.hs
@@ -34,7 +34,7 @@ import           Control.Monad.Logger
 import           Control.Monad.Reader
 import           Data.Bifoldable
 import           Data.Bifunctor
-import qualified Data.Bifunctor.TH               as TH
+import qualified Data.Bifunctor.TH             as TH
 import           Data.Bitraversable
 import           Data.Functor.Classes
 import           Data.Kind
@@ -46,8 +46,8 @@ import           Data.Text
                    (Text, pack)
 import           Database.Persist
 import           Database.Persist.Sqlite
-import           Database.Sqlite                 hiding
-                   (step)
+import           Database.Sqlite               hiding
+                   (step, open')
 import           GHC.Generics
                    (Generic, Generic1)
 import           Prelude
@@ -56,9 +56,9 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
 import           Test.StateMachine
 import           Test.StateMachine.DotDrawing
-import           Test.StateMachine.TreeDiff.Expr
+import           Test.StateMachine.TreeDiff
 import           Test.StateMachine.Types
-import qualified Test.StateMachine.Types.Rank2   as Rank2
+import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 import           Schema
 

--- a/test/ShrinkingProps.hs
+++ b/test/ShrinkingProps.hs
@@ -66,7 +66,6 @@ import           Test.StateMachine
 import qualified Test.StateMachine.Parallel    as QSM
 import qualified Test.StateMachine.Sequential  as QSM
 import           Test.StateMachine.TreeDiff
-                   (defaultExprViaShow)
 import qualified Test.StateMachine.Types       as QSM
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.StateMachine.Utils

--- a/test/TicketDispenser.hs
+++ b/test/TicketDispenser.hs
@@ -62,6 +62,7 @@ import           Test.QuickCheck.Monadic
                    (PropertyM, monadicIO)
 
 import           Test.StateMachine
+import           Test.StateMachine.TreeDiff
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------

--- a/test/UnionFind.hs
+++ b/test/UnionFind.hs
@@ -40,6 +40,7 @@ import           Test.QuickCheck.Monadic
                    (monadicIO)
 
 import           Test.StateMachine
+import           Test.StateMachine.TreeDiff
 import qualified Test.StateMachine.Types.Rank2      as Rank2
 import           Test.StateMachine.Types.References
 import           Test.StateMachine.Z

--- a/tree-diff/Test/StateMachine/TreeDiff.hs
+++ b/tree-diff/Test/StateMachine/TreeDiff.hs
@@ -16,6 +16,8 @@ module Test.StateMachine.TreeDiff (
     module Test.StateMachine.TreeDiff.Pretty,
     ) where
 
-import Test.StateMachine.TreeDiff.Expr
-import Test.StateMachine.TreeDiff.Class
-import Test.StateMachine.TreeDiff.Pretty
+import           Test.StateMachine.TreeDiff.Class
+import           Test.StateMachine.TreeDiff.Diffing
+                   ()
+import           Test.StateMachine.TreeDiff.Expr
+import           Test.StateMachine.TreeDiff.Pretty

--- a/tree-diff/Test/StateMachine/TreeDiff/Class.hs
+++ b/tree-diff/Test/StateMachine/TreeDiff/Class.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DefaultSignatures   #-}
 {-# LANGUAGE FlexibleContexts    #-}
@@ -15,50 +14,61 @@ module Test.StateMachine.TreeDiff.Class (
     sopToExpr,
     ) where
 
-import Data.Foldable      (toList)
-import Data.Proxy         (Proxy (..))
-import Test.StateMachine.TreeDiff.Expr
-import Data.List.Compat      (uncons)
-import Generics.SOP
-       (All, All2, ConstructorInfo (..), DatatypeInfo (..), FieldInfo (..),
-       I (..), K (..), NP (..), SOP (..), constructorInfo, hcliftA2, hcmap,
-       hcollapse, mapIK)
-import Generics.SOP.GGP   (GCode, GDatatypeInfo, GFrom, gdatatypeInfo, gfrom)
-import GHC.Generics       (Generic)
+import           Data.Foldable
+                   (toList)
+import           Data.List.Compat
+                   (uncons)
+import           Data.Proxy
+                   (Proxy(..))
+import           Generics.SOP
+                   (All, All2, ConstructorInfo(..), DatatypeInfo(..),
+                   FieldInfo(..), I(..), K(..), NP(..), SOP(..),
+                   constructorInfo, hcliftA2, hcmap, hcollapse, mapIK)
+import           Generics.SOP.GGP
+                   (GCode, GDatatypeInfo, GFrom, gdatatypeInfo, gfrom)
+import           GHC.Generics
+                   (Generic)
+import           Test.StateMachine.TreeDiff.Expr
 
-import qualified Data.Map as Map
+import qualified Data.Map                        as Map
 
 -- Instances
-import Control.Applicative   (Const (..), ZipList (..))
-import Data.Fixed            (Fixed, HasResolution)
-import Data.Functor.Identity (Identity (..))
-import Data.Int
-import Data.List.NonEmpty    (NonEmpty (..))
-import Data.Void             (Void)
-import Data.Word
-import Numeric.Natural       (Natural)
+import           Control.Applicative
+                   (Const(..), ZipList(..))
+import           Data.Fixed
+                   (Fixed, HasResolution)
+import           Data.Functor.Identity
+                   (Identity(..))
+import           Data.Int
+import           Data.List.NonEmpty
+                   (NonEmpty(..))
+import           Data.Void
+                   (Void)
+import           Data.Word
+import           Numeric.Natural
+                   (Natural)
 
-import qualified Data.Monoid    as Mon
-import qualified Data.Ratio     as Ratio
-import qualified Data.Semigroup as Semi
+import qualified Data.Monoid                     as Mon
+import qualified Data.Ratio                      as Ratio
+import qualified Data.Semigroup                  as Semi
 
 -- containers
-import qualified Data.IntMap   as IntMap
-import qualified Data.IntSet   as IntSet
-import qualified Data.Sequence as Seq
-import qualified Data.Set      as Set
-import qualified Data.Tree     as Tree
+import qualified Data.IntMap                     as IntMap
+import qualified Data.IntSet                     as IntSet
+import qualified Data.Sequence                   as Seq
+import qualified Data.Set                        as Set
+import qualified Data.Tree                       as Tree
 
 -- text
-import qualified Data.Text      as T
-import qualified Data.Text.Lazy as LT
+import qualified Data.Text                       as T
+import qualified Data.Text.Lazy                  as LT
 
 -- time
-import qualified Data.Time as Time
+import qualified Data.Time                       as Time
 
 -- bytestring
-import qualified Data.ByteString       as BS
-import qualified Data.ByteString.Lazy  as LBS
+import qualified Data.ByteString                 as BS
+import qualified Data.ByteString.Lazy            as LBS
 -- import qualified Data.ByteString.Short as SBS
 
 -- scientific
@@ -68,10 +78,10 @@ import qualified Data.ByteString.Lazy  as LBS
 -- import qualified Data.UUID.Types as UUID
 
 -- vector
-import qualified Data.Vector           as V
-import qualified Data.Vector.Primitive as VP
-import qualified Data.Vector.Storable  as VS
-import qualified Data.Vector.Unboxed   as VU
+import qualified Data.Vector                     as V
+import qualified Data.Vector.Primitive           as VP
+import qualified Data.Vector.Storable            as VS
+import qualified Data.Vector.Unboxed             as VU
 
 -- tagged
 -- import Data.Tagged (Tagged (..))

--- a/tree-diff/Test/StateMachine/TreeDiff/Diffing.hs
+++ b/tree-diff/Test/StateMachine/TreeDiff/Diffing.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Implements @CanDiff@ with our vendored version of @tree-diff@.
+module Test.StateMachine.TreeDiff.Diffing () where
+
+import           Data.SOP
+import           Test.StateMachine.Diffing
+import qualified Test.StateMachine.Lockstep.NAry    as NAry
+import qualified Test.StateMachine.Lockstep.Simple  as Simple
+import           Test.StateMachine.TreeDiff.Class
+import           Test.StateMachine.TreeDiff.Expr
+import           Test.StateMachine.TreeDiff.Pretty
+import           Test.StateMachine.Types.References
+
+instance ToExpr x => CanDiff x where
+  type ADiff  x = Edit EditExpr
+  type AnExpr x = Expr
+
+  toDiff             = toExpr
+  exprDiff         _ = Test.StateMachine.TreeDiff.Expr.exprDiff
+  diffToDocCompact _ = ansiWlBgEditExprCompact
+  diffToDoc        _ = ansiWlBgEditExpr
+  exprToDoc        _ = ansiWlBgExpr
+
+-- References
+
+deriving newtype instance ToExpr Var
+
+instance ToExpr a => ToExpr (Symbolic a) where
+  toExpr (Symbolic x) = toExpr x
+
+instance ToExpr a => ToExpr (Concrete a) where
+  toExpr (Concrete x) = toExpr x
+
+instance ToExpr (r a) => ToExpr (Reference a r)
+
+instance ToExpr (Opaque a) where
+  toExpr _ = App "Opaque" []
+
+-- Simple
+
+instance ToExpr (Simple.MockHandle t)
+      => ToExpr (NAry.MockHandleN (Simple.Simple t) (Simple.RealHandle t)) where
+  toExpr (Simple.SimpleToMock h) = toExpr h
+
+-- NAry
+
+deriving
+  newtype
+  instance (ToExpr a, ToExpr (NAry.MockHandleN t a)) => ToExpr (NAry.Refs t Concrete a)
+
+instance All (And ToExpr (Compose ToExpr (NAry.MockHandleN t))) (NAry.RealHandles t)
+      => ToExpr (NAry.Refss t Concrete) where
+  toExpr = Lst
+         . hcollapse
+         . hcmap (Proxy @(And ToExpr (Compose ToExpr (NAry.MockHandleN t)))) toExprOne
+         . NAry.unRefss
+    where
+      toExprOne :: (ToExpr a, ToExpr (NAry.MockHandleN t a))
+                => NAry.Refs t Concrete a -> K Expr a
+      toExprOne = K . toExpr
+
+instance ( ToExpr (NAry.MockState t)
+         , All (And ToExpr (Compose ToExpr (NAry.MockHandleN t))) (NAry.RealHandles t)
+         ) => ToExpr (NAry.Model t Concrete)

--- a/tree-diff/Test/StateMachine/TreeDiff/Expr.hs
+++ b/tree-diff/Test/StateMachine/TreeDiff/Expr.hs
@@ -9,14 +9,16 @@ module Test.StateMachine.TreeDiff.Expr (
     exprDiff,
     ) where
 
-import Prelude ()
-import Prelude.Compat
+import           Prelude
+                   ()
+import           Prelude.Compat
 
-import Data.Map           (Map)
-import Test.StateMachine.TreeDiff.List
+import           Data.Map
+                   (Map)
+import           Test.StateMachine.TreeDiff.List
 
-import qualified Data.Map        as Map
-import qualified Test.QuickCheck as QC
+import qualified Data.Map                        as Map
+import qualified Test.QuickCheck                 as QC
 
 -- | Constructor name is a string
 type ConstructorName = String

--- a/tree-diff/Test/StateMachine/TreeDiff/List.hs
+++ b/tree-diff/Test/StateMachine/TreeDiff/List.hs
@@ -2,9 +2,10 @@
 -- | A list diff.
 module Test.StateMachine.TreeDiff.List (diffBy, Edit (..)) where
 
-import Data.List.Compat (sortOn)
-import qualified Data.MemoTrie as M
-import qualified Data.Vector as V
+import           Data.List.Compat
+                   (sortOn)
+import qualified Data.MemoTrie    as M
+import qualified Data.Vector      as V
 
 -- | List edit operations
 --

--- a/tree-diff/Test/StateMachine/TreeDiff/Pretty.hs
+++ b/tree-diff/Test/StateMachine/TreeDiff/Pretty.hs
@@ -24,29 +24,33 @@ module Test.StateMachine.TreeDiff.Pretty (
     escapeName,
     ) where
 
-import Data.Char          (isAlphaNum, isPunctuation, isSymbol, ord)
-import Data.Either        (partitionEithers)
-import Test.StateMachine.TreeDiff.Expr
-import Numeric            (showHex)
-import Text.Read          (readMaybe)
+import           Data.Char
+                   (isAlphaNum, isPunctuation, isSymbol, ord)
+import           Data.Either
+                   (partitionEithers)
+import           Numeric
+                   (showHex)
+import           Test.StateMachine.TreeDiff.Expr
+import           Text.Read
+                   (readMaybe)
 
 
-import qualified Data.Map                     as Map
-import qualified Text.PrettyPrint             as HJ
-import qualified Text.PrettyPrint.ANSI.Leijen as WL
+import qualified Data.Map                        as Map
+import qualified Text.PrettyPrint                as HJ
+import qualified Text.PrettyPrint.ANSI.Leijen    as WL
 
 -- | Because we don't want to commit to single pretty printing library,
 -- we use explicit dictionary.
 data Pretty doc = Pretty
-    { ppCon        :: ConstructorName -> doc
-    , ppRec        :: [(FieldName, doc)] -> doc
-    , ppLst        :: [doc] -> doc
-    , ppCpy        :: doc -> doc
-    , ppIns        :: doc -> doc
-    , ppDel        :: doc -> doc
-    , ppSep        :: [doc] -> doc
-    , ppParens     :: doc -> doc
-    , ppHang       :: doc -> doc -> doc
+    { ppCon    :: ConstructorName -> doc
+    , ppRec    :: [(FieldName, doc)] -> doc
+    , ppLst    :: [doc] -> doc
+    , ppCpy    :: doc -> doc
+    , ppIns    :: doc -> doc
+    , ppDel    :: doc -> doc
+    , ppSep    :: [doc] -> doc
+    , ppParens :: doc -> doc
+    , ppHang   :: doc -> doc -> doc
     }
 
 -- | Escape field or constructor name
@@ -101,7 +105,7 @@ escapeName n
     isValidString s
         | length s >= 2 && head s == '"' && last s == '"' =
             case readMaybe s :: Maybe String of
-                Just _ -> True
+                Just _  -> True
                 Nothing -> False
     isValidString _         = False
 

--- a/tree-diff/Test/StateMachine/TreeDiff/Tree.hs
+++ b/tree-diff/Test/StateMachine/TreeDiff/Tree.hs
@@ -2,11 +2,12 @@
 -- | Tree diffing working on @containers@ 'Tree'.
 module Test.StateMachine.TreeDiff.Tree (treeDiff, EditTree (..), Edit (..)) where
 
-import Data.Tree          (Tree (..))
-import Test.StateMachine.TreeDiff.List
+import           Data.Tree
+                   (Tree(..))
+import           Test.StateMachine.TreeDiff.List
 
 #ifdef __DOCTEST__
-import qualified Text.PrettyPrint as PP
+import qualified Text.PrettyPrint                as PP
 #endif
 
 -- | A breadth-traversal diff.


### PR DESCRIPTION
This way, users that want to not use upstream tree-diff can depend on QSM as follows:
```
  build-depends:
    , quickcheck-state-machine:{quickcheck-state-machine, vendored-tree-diff}
```

And for users that want to use upstream tree-diff then they can depend only on QSM and they will have to figure out their own way of providing `CanDiff` instances.

```
  build-depends:
    , quickcheck-state-machine
```
