### PR TITLE
Change visibility of sublibrary

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -31,6 +31,7 @@ tested-with:     GHC ==8.8.4 || ==8.10.7 || ==9.2.8 || ==9.4.7 || ==9.6.3
 -- https://github.com/stevana/quickcheck-state-machine#readme for how to depend
 -- on either version.
 library no-vendored-treediff
+  visibility:       public
   hs-source-dirs:   src
   ghc-options:      -Wall
   exposed-modules:


### PR DESCRIPTION
I forgot this, otherwise external projects cannot import this sub-library