### PR TITLE
Replicate parallel executions in `forallParallelCommands`

### DIFF
--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -19,7 +19,6 @@ module Test.StateMachine
     forAllCommands
   , existsCommands
   , runCommands
-  , runCommandsWithSetup
   , prettyCommands
   , prettyCommands'
   , checkCommandNames
@@ -35,17 +34,12 @@ module Test.StateMachine
   -- * Parallel property combinators
   , forAllParallelCommands
   , forAllNParallelCommands
+  , forAllParallelCommandsNTimes
+  , forAllNParallelCommandsNTimes
   , runNParallelCommands
-  , runNParallelCommandsWithSetup
   , runParallelCommands
-  , runParallelCommandsWithSetup
   , runParallelCommands'
-  , runParallelCommandsNTimes
-  , runParallelCommandsNTimesWithSetup
-  , runNParallelCommandsNTimes'
-  , runParallelCommandsNTimes'
-  , runNParallelCommandsNTimes
-  , runNParallelCommandsNTimesWithSetup
+  , runNParallelCommands'
   , prettyNParallelCommands
   , prettyParallelCommands
   , prettyParallelCommandsWithOpts

--- a/src/Test/StateMachine/ConstructorName.hs
+++ b/src/Test/StateMachine/ConstructorName.hs
@@ -19,9 +19,9 @@ import           Data.Kind
 import           Data.Proxy
                    (Proxy(Proxy))
 import           GHC.Generics
-                   ((:*:)((:*:)), (:+:)(L1, R1), C, Constructor, D,
-                   Generic1, K1, M1, Rec1, Rep1, S, U1, conName, from1,
-                   unM1, unRec1)
+                   (C, Constructor, D, Generic1, K1, M1, Rec1, Rep1, S,
+                   U1, conName, from1, unM1, unRec1, (:*:)((:*:)),
+                   (:+:)(L1, R1))
 import           Prelude
 
 import           Test.StateMachine.Types

--- a/src/Test/StateMachine/Parallel.hs
+++ b/src/Test/StateMachine/Parallel.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -62,7 +62,7 @@ module Test.StateMachine.Parallel
 import           Control.Monad
                    (when)
 import           Control.Monad.Catch
-                   (MonadMask, generalBracket, ExitCase (..))
+                   (ExitCase(..), MonadMask, generalBracket)
 import           Control.Monad.State.Strict
                    (runStateT)
 import           Data.Bifunctor
@@ -70,7 +70,7 @@ import           Data.Bifunctor
 import           Data.Foldable
                    (toList)
 import           Data.List
-                   (find, partition, permutations, foldl')
+                   (find, foldl', partition, permutations)
 import qualified Data.Map.Strict                   as Map
 import           Data.Maybe
                    (fromMaybe, mapMaybe)
@@ -91,8 +91,8 @@ import           Text.PrettyPrint.ANSI.Leijen
 import           Text.Show.Pretty
                    (ppShow)
 import           UnliftIO
-                   (MonadIO, MonadUnliftIO, concurrently,
-                   forConcurrently, newTChanIO, TChan)
+                   (MonadIO, MonadUnliftIO, TChan, concurrently,
+                   forConcurrently, newTChanIO)
 
 import           Test.StateMachine.BoxDrawer
 import           Test.StateMachine.ConstructorName
@@ -102,7 +102,7 @@ import           Test.StateMachine.Sequential
 import           Test.StateMachine.Types
 import qualified Test.StateMachine.Types.Rank2     as Rank2
 import           Test.StateMachine.Utils
-import qualified Text.PrettyPrint.ANSI.Leijen as PP
+import qualified Text.PrettyPrint.ANSI.Leijen      as PP
 
 ------------------------------------------------------------------------
 

--- a/src/Test/StateMachine/Parallel.hs
+++ b/src/Test/StateMachine/Parallel.hs
@@ -1,8 +1,8 @@
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -17,69 +17,52 @@
 -- This module contains helpers for generating, shrinking, and checking
 -- parallel programs.
 --
--- Note that:
---
--- - the @.*NParallelCommands@ functions and the 'NParallelCommands' datatype
---   are expected to be used when you want to run @N@ concurrent threads running
---   at the same time and repeat each test 10 (by default) times to get
---   sufficient randomness on the RTS scheduling of concurrent actions.
---
--- - the @.*ParallelCommandsNTimes@ functions and the 'ParallelCommands'
---   datatype are expected to be used when you want to run the test with 2
---   concurrent threads and repeat each test @N@ times to get sufficient
---   randomness on the RTS scheduling of concurrent actions.
---
--- - the @.*NParallelCommandsNTime@ functions do both of the above points at the
---   same time, in particular they take an 'NParallelCommands' value generated
---   to be run by some number of threads concurrently, and they take as input
---   how many times each test should be repeated.
---
--- - the @run.*WithSetup@ functions receive a monadic action that must
---   initialize the StateMachine which will be used at the beginning of each
---   repetition of each sequence of commands. See the section in the
---   [README](https://github.com/stevana/quickcheck-state-machine#sut-initialization)
---   for more context.
---
 -----------------------------------------------------------------------------
 
 module Test.StateMachine.Parallel
-  ( forAllNParallelCommands
+  ( -- forall
+    forAllNParallelCommands
+  , forAllNParallelCommandsNTimes
+  , forAllParallelCommandsNTimes
   , forAllParallelCommands
+
+    -- generate
   , generateNParallelCommands
   , generateParallelCommands
+
+    -- shrink
   , shrinkNParallelCommands
   , shrinkParallelCommands
   , shrinkAndValidateNParallel
   , shrinkAndValidateParallel
   , shrinkCommands'
-  , runNParallelCommands
-  , runNParallelCommandsWithSetup
+
+    -- run
   , runParallelCommands
-  , runParallelCommandsWithSetup
   , runParallelCommands'
-  , runNParallelCommandsNTimes
-  , runNParallelCommandsNTimesWithSetup
-  , runParallelCommandsNTimes
-  , runParallelCommandsNTimesWithSetup
-  , runNParallelCommandsNTimes'
-  , runParallelCommandsNTimes'
-  , executeParallelCommands
-  , linearise
-  , toBoxDrawings
+  , runNParallelCommands
+  , runNParallelCommands'
+
+    -- pretty
   , prettyNParallelCommands
   , prettyParallelCommands
   , prettyParallelCommandsWithOpts
   , prettyNParallelCommandsWithOpts
+
+    -- misc
   , advanceModel
   , checkCommandNamesParallel
   , coverCommandNamesParallel
   , commandNamesParallel
+  , linearise
+  , toBoxDrawings
+  , executeParallelCommands
   ) where
 
 import           Control.Monad
-                   (replicateM, when)
+                   (when)
 import           Control.Monad.Catch
-                   (MonadMask(..), ExitCase(..))
+                   (MonadMask, generalBracket, ExitCase (..))
 import           Control.Monad.State.Strict
                    (runStateT)
 import           Data.Bifunctor
@@ -100,7 +83,7 @@ import           Data.Tree
 import           Prelude
 import           Test.QuickCheck
                    (Gen, Property, Testable, choose, forAllShrinkShow,
-                   property, sized)
+                   property, sized, (.&&.))
 import           Test.QuickCheck.Monadic
                    (PropertyM, run)
 import           Text.PrettyPrint.ANSI.Leijen
@@ -109,8 +92,7 @@ import           Text.Show.Pretty
                    (ppShow)
 import           UnliftIO
                    (MonadIO, MonadUnliftIO, concurrently,
-                   forConcurrently, newTChanIO)
-import qualified UnliftIO as UIO
+                   forConcurrently, newTChanIO, TChan)
 
 import           Test.StateMachine.BoxDrawer
 import           Test.StateMachine.ConstructorName
@@ -124,6 +106,18 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 ------------------------------------------------------------------------
 
+forAllParallelCommandsNTimes :: Testable prop
+                             => (Show (cmd Symbolic), Show (resp Symbolic), Show (model Symbolic))
+                             => (Rank2.Traversable cmd, Rank2.Foldable resp)
+                             => StateMachine model cmd m resp
+                             -> Maybe Int
+                             -> Int
+                             -> (ParallelCommands cmd resp -> prop)     -- ^ Predicate.
+                             -> Property
+forAllParallelCommandsNTimes sm mminSize reps prop =
+  forAllShrinkShow (generateParallelCommands sm mminSize) (shrinkParallelCommands sm) ppShow
+    (\parCmds -> foldl' (.&&.) (property True) $ replicate reps $ prop parCmds)
+
 forAllParallelCommands :: Testable prop
                        => (Show (cmd Symbolic), Show (resp Symbolic), Show (model Symbolic))
                        => (Rank2.Traversable cmd, Rank2.Foldable resp)
@@ -132,8 +126,19 @@ forAllParallelCommands :: Testable prop
                        -> (ParallelCommands cmd resp -> prop)     -- ^ Predicate.
                        -> Property
 forAllParallelCommands sm mminSize =
-  forAllShrinkShow (generateParallelCommands sm mminSize) (shrinkParallelCommands sm) ppShow
+  forAllParallelCommandsNTimes sm mminSize 10
 
+forAllNParallelCommandsNTimes :: Testable prop
+                             => (Show (cmd Symbolic), Show (resp Symbolic), Show (model Symbolic))
+                             => (Rank2.Traversable cmd, Rank2.Foldable resp)
+                             => StateMachine model cmd m resp
+                             -> Int                                     -- ^ Number of threads
+                             -> Int
+                             -> (NParallelCommands cmd resp -> prop)     -- ^ Predicate.
+                             -> Property
+forAllNParallelCommandsNTimes sm np reps prop =
+  forAllShrinkShow (generateNParallelCommands sm np) (shrinkNParallelCommands sm) ppShow
+    (\parCmds -> foldl' (.&&.) (property True) $ replicate reps $ prop parCmds)
 
 forAllNParallelCommands :: Testable prop
                         => (Show (cmd Symbolic), Show (resp Symbolic), Show (model Symbolic))
@@ -143,8 +148,7 @@ forAllNParallelCommands :: Testable prop
                         -> (NParallelCommands cmd resp -> prop)     -- ^ Predicate.
                         -> Property
 forAllNParallelCommands sm np =
-  forAllShrinkShow (generateNParallelCommands sm np) (shrinkNParallelCommands sm) ppShow
-
+  forAllNParallelCommandsNTimes sm np 10
 
 -- | Generate parallel commands.
 --
@@ -498,170 +502,66 @@ shrinkAndValidateNParallel sm = \shouldShrink  (ParallelCommands prefix suffixes
 ------------------------------------------------------------------------
 
 runParallelCommands :: (Show (cmd Concrete), Show (resp Concrete))
-                    => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                    => (MonadMask m, MonadUnliftIO m)
-                    => StateMachine model cmd m resp
-                    -> ParallelCommands cmd resp
-                    -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runParallelCommands = runParallelCommandsNTimes 10
-
-runParallelCommandsWithSetup :: (Show (cmd Concrete), Show (resp Concrete))
-                    => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                    => (MonadMask m, MonadUnliftIO m)
-                    => m (StateMachine model cmd m resp)
-                    -> ParallelCommands cmd resp
-                    -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runParallelCommandsWithSetup = runParallelCommandsNTimesWithSetup 10
+                          => (Rank2.Traversable cmd, Rank2.Foldable resp)
+                          => (MonadMask m, MonadUnliftIO m)
+                          => StateMachine model cmd m resp
+                          -> ParallelCommands cmd resp
+                          -> PropertyM m (History cmd resp, model Concrete, Logic)
+runParallelCommands sm cmds = do
+    hchan <- newTChanIO
+    ((hist, model, reason1, reason2), ()) <- run $
+      fst <$> generalBracket
+              (pure ())
+              (\_ ec -> case ec of
+                            ExitCaseSuccess ((_, model, _, _), _) -> cleanup sm model
+                            _ -> getChanContents hchan >>= cleanup sm . mkModel sm . History
+              )
+              (\_ -> (,()) <$> executeParallelCommands sm cmds hchan True)
+    return (hist, model, logicReason (combineReasons [reason1, reason2]) .&& linearise sm hist)
 
 runParallelCommands' :: (Show (cmd Concrete), Show (resp Concrete))
-                     => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                     => (MonadMask m, MonadUnliftIO m)
-                     => m (StateMachine model cmd m resp)
-                     -> (cmd Concrete -> resp Concrete)
-                     -> ParallelCommands cmd resp
-                     -> PropertyM m [(History cmd resp, model Concrete,  Logic)]
-runParallelCommands' = runParallelCommandsNTimes' 10
-
-runNParallelCommands :: (Show (cmd Concrete), Show (resp Concrete))
-                     => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                     => (MonadMask m, MonadUnliftIO m)
-                     => StateMachine model cmd m resp
-                     -> NParallelCommands cmd resp
-                     -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runNParallelCommands = runNParallelCommandsNTimes 10
-
-runNParallelCommandsWithSetup :: (Show (cmd Concrete), Show (resp Concrete))
-                     => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                     => (MonadMask m, MonadUnliftIO m)
-                     => m (StateMachine model cmd m resp)
-                     -> NParallelCommands cmd resp
-                     -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runNParallelCommandsWithSetup = runNParallelCommandsNTimesWithSetup 10
-
-runParallelCommandsNTimes :: (Show (cmd Concrete), Show (resp Concrete))
-                          => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                          => (MonadMask m, MonadUnliftIO m)
-                          => Int -- ^ How many times to execute the parallel program.
-                          -> StateMachine model cmd m resp
-                          -> ParallelCommands cmd resp
-                          -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runParallelCommandsNTimes n sm = runParallelCommandsNTimesWithSetup n (pure sm)
-
-runParallelCommandsNTimesWithSetup :: (Show (cmd Concrete), Show (resp Concrete))
-                          => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                          => (MonadMask m, MonadUnliftIO m)
-                          => Int -- ^ How many times to execute the parallel program.
-                          -> m (StateMachine model cmd m resp)
-                          -> ParallelCommands cmd resp
-                          -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runParallelCommandsNTimesWithSetup n msm cmds =
-  replicateM n $ do
-    hchan <- newTChanIO
-    ((hist, model, reason1, reason2), sm') <- run $
-      fst <$> generalBracket
-              msm
-              (\sm' ec -> case ec of
-                            ExitCaseSuccess ((_, model, _, _), _) -> cleanup sm' model
-                            _ -> getChanContents hchan >>= cleanup sm' . mkModel sm' . History
-              )
-              (\sm' -> (,sm') <$> executeParallelCommands sm' cmds hchan True)
-    return (hist, model, logicReason (combineReasons [reason1, reason2]) .&& linearise sm' hist)
-
-runParallelCommandsNTimes' :: (Show (cmd Concrete), Show (resp Concrete))
                            => (Rank2.Traversable cmd, Rank2.Foldable resp)
                            => (MonadMask m, MonadUnliftIO m)
-                           => Int -- ^ How many times to execute the parallel program.
-                           -> m (StateMachine model cmd m resp)
+                           => StateMachine model cmd m resp
                            -> (cmd Concrete -> resp Concrete)
                            -> ParallelCommands cmd resp
-                           -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runParallelCommandsNTimes' n msm complete cmds =
-  replicateM n $ do
+                           -> PropertyM m (History cmd resp, model Concrete, Logic)
+runParallelCommands' sm complete cmds = do
     hchan <- newTChanIO
-    ((hist, model, _, _), sm') <- run $
+    ((hist, model, _reason1, _reason2), ()) <- run $
       fst <$> generalBracket
-              msm
-              (\sm' ec -> case ec of
-                            ExitCaseSuccess ((_, model, _, _), _) -> cleanup sm' model
-                            _ -> getChanContents hchan >>= cleanup sm' . mkModel sm' . History
+              (pure ())
+              (\_ ec -> case ec of
+                            ExitCaseSuccess ((_, model, _, _), _) -> cleanup sm model
+                            _ -> getChanContents hchan >>= cleanup sm . mkModel sm . History
               )
-              (\sm' -> (,sm') <$> executeParallelCommands sm' cmds hchan True)
+              (\_ -> (,()) <$> executeParallelCommands sm cmds hchan True)
     let hist' = completeHistory complete hist
-    return (hist', model, linearise sm' hist')
-
-
-runNParallelCommandsNTimes :: (Show (cmd Concrete), Show (resp Concrete))
-                           => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                           => (MonadMask m, MonadUnliftIO m)
-                           => Int -- ^ How many times to execute the parallel program.
-                           -> StateMachine model cmd m resp
-                           -> NParallelCommands cmd resp
-                           -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runNParallelCommandsNTimes n sm = runNParallelCommandsNTimesWithSetup n (pure sm)
-
-runNParallelCommandsNTimesWithSetup :: (Show (cmd Concrete), Show (resp Concrete))
-                           => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                           => (MonadMask m, MonadUnliftIO m)
-                           => Int -- ^ How many times to execute the parallel program.
-                           -> m (StateMachine model cmd m resp)
-                           -> NParallelCommands cmd resp
-                           -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runNParallelCommandsNTimesWithSetup n msm cmds =
-  replicateM n $ do
-    hchan <- newTChanIO
-    ((hist, model, reason), sm') <- run $
-      fst <$> generalBracket
-              msm
-              (\sm' ec -> case ec of
-                            ExitCaseSuccess ((_, model, _), _) -> cleanup sm' model
-                            _ -> getChanContents hchan >>= cleanup sm' . mkModel sm' . History
-              )
-              (\sm' -> (,sm') <$> executeNParallelCommands sm' cmds hchan True)
-    return (hist, model, logicReason reason .&& linearise sm' hist)
-
-runNParallelCommandsNTimes' :: (Show (cmd Concrete), Show (resp Concrete))
-                            => (Rank2.Traversable cmd, Rank2.Foldable resp)
-                            => (MonadMask m, MonadUnliftIO m)
-                            => Int -- ^ How many times to execute the parallel program.
-                            -> m (StateMachine model cmd m resp)
-                            -> (cmd Concrete -> resp Concrete)
-                            -> NParallelCommands cmd resp
-                            -> PropertyM m [(History cmd resp, model Concrete, Logic)]
-runNParallelCommandsNTimes' n msm complete cmds =
-  replicateM n $ do
-    hchan <- newTChanIO
-    ((hist, model, _reason), sm') <- run $
-      fst <$> generalBracket
-              msm
-              (\sm' ec -> case ec of
-                            ExitCaseSuccess ((_, model, _), _) -> cleanup sm' model
-                            _ -> getChanContents hchan >>= cleanup sm' . mkModel sm' . History
-              )
-              (\sm' -> (,sm') <$> executeNParallelCommands sm' cmds hchan True)
-    let hist' = completeHistory complete hist
-    return (hist, model, linearise sm' hist')
+    return (hist', model, linearise sm hist')
 
 executeParallelCommands :: (Show (cmd Concrete), Show (resp Concrete))
                         => (Rank2.Traversable cmd, Rank2.Foldable resp)
                         => (MonadMask m, MonadUnliftIO m)
                         => StateMachine model cmd m resp
                         -> ParallelCommands cmd resp
-                        -> UIO.TChan (Pid, HistoryEvent cmd resp)
+                        -> TChan (Pid, HistoryEvent cmd resp)
                         -> Bool
                         -> m (History cmd resp, model Concrete, Reason, Reason)
-executeParallelCommands sm@StateMachine{ initModel } (ParallelCommands prefix suffixes) hchan stopOnError = do
-
-  (reason0, (env0, _smodel, _counter, cmodel)) <- runStateT
-      (executeCommands sm hchan (Pid 0) CheckEverything prefix)
-      (emptyEnvironment, initModel, newCounter, initModel)
-  if reason0 /= Ok
-  then do
-    hist <- getChanContents hchan
-    return (History hist, cmodel, reason0, reason0)
-  else do
-    (reason1, reason2, _) <- go (Ok, Ok, env0) suffixes
-    hist <- getChanContents hchan
-    return (History hist, cmodel, reason1, reason2)
+executeParallelCommands sm@StateMachine{ initModel, cleanup } (ParallelCommands prefix suffixes) hchan stopOnError = do
+    (reason0, (env0, _smodel, _counter, _cmodel)) <-
+      runStateT
+        (executeCommands sm hchan (Pid 0) CheckEverything prefix)
+        (emptyEnvironment, initModel, newCounter, initModel)
+    if reason0 /= Ok
+    then do
+      hist <- getChanContents hchan
+      let model = mkModel sm $ History hist
+      return (History hist, model, reason0, reason0)
+    else do
+      (reason1, reason2, _) <- go (Ok, Ok, env0) suffixes
+      hist <- getChanContents hchan
+      let model = mkModel sm $ History hist
+      return (History hist, model, reason1, reason2)
   where
     go (res1, res2, env) []                         = return (res1, res2, env)
     go (Ok,   Ok,   env) (Pair cmds1 cmds2 : pairs) = do
@@ -723,26 +623,67 @@ logicReason :: Reason -> Logic
 logicReason Ok = Top
 logicReason r  = Annotate (show r) Bot
 
+runNParallelCommands :: (Show (cmd Concrete), Show (resp Concrete))
+                     => (Rank2.Traversable cmd, Rank2.Foldable resp)
+                     => (MonadMask m, MonadUnliftIO m)
+                     => StateMachine model cmd m resp
+                     -> NParallelCommands cmd resp
+                     -> PropertyM m (History cmd resp, model Concrete, Logic)
+runNParallelCommands sm cmds = do
+    hchan <- newTChanIO
+    ((hist, model, reason), ()) <- run $
+      fst <$> generalBracket
+              (pure ())
+              (\_ ec -> case ec of
+                            ExitCaseSuccess ((_, model, _), _) -> cleanup sm model
+                            _ -> getChanContents hchan >>= cleanup sm . mkModel sm . History
+              )
+              (\_ -> (,()) <$> executeNParallelCommands sm cmds hchan True)
+    return (hist, model, logicReason reason .&& linearise sm hist)
+
+runNParallelCommands' :: (Show (cmd Concrete), Show (resp Concrete))
+                      => (Rank2.Traversable cmd, Rank2.Foldable resp)
+                      => (MonadMask m, MonadUnliftIO m)
+                      => StateMachine model cmd m resp
+                      -> (cmd Concrete -> resp Concrete)
+                      -> NParallelCommands cmd resp
+                      -> PropertyM m (History cmd resp, model Concrete, Logic)
+runNParallelCommands' sm complete cmds = do
+    hchan <- newTChanIO
+    ((hist, model, _reason), ()) <- run $
+      fst <$> generalBracket
+              (pure ())
+              (\_ ec -> case ec of
+                            ExitCaseSuccess ((_, model, _), _) -> cleanup sm model
+                            _ -> getChanContents hchan >>= cleanup sm . mkModel sm . History
+              )
+              (\_ -> (,()) <$> executeNParallelCommands sm cmds hchan True)
+    let hist' = completeHistory complete hist
+    return (hist, model, linearise sm hist')
+
 executeNParallelCommands :: (Rank2.Traversable cmd, Show (cmd Concrete), Rank2.Foldable resp)
                          => Show (resp Concrete)
                          => (MonadMask m, MonadUnliftIO m)
                          => StateMachine model cmd m resp
                          -> NParallelCommands cmd resp
-                         -> UIO.TChan (Pid, HistoryEvent cmd resp)
+                         -> TChan (Pid, HistoryEvent cmd resp)
                          -> Bool
                          -> m (History cmd resp, model Concrete, Reason)
-executeNParallelCommands sm@StateMachine{ initModel } (ParallelCommands prefix suffixes) hchan stopOnError = do
-  (reason0, (env0, _smodel, _counter, cmodel)) <- runStateT
-      (executeCommands sm hchan (Pid 0) CheckEverything prefix)
-      (emptyEnvironment, initModel, newCounter, initModel)
-  if reason0 /= Ok
-  then do
-    hist <- getChanContents hchan
-    return (History hist, cmodel, reason0)
-  else do
-    (errors, _) <- go (Map.empty, env0) suffixes
-    hist <- getChanContents hchan
-    return (History hist, cmodel, combineReasons $ Map.elems errors)
+executeNParallelCommands sm@StateMachine{ initModel, cleanup } (ParallelCommands prefix suffixes) hchan stopOnError = do
+    (reason0, (env0, _smodel, _counter, _cmodel)) <-
+      runStateT
+        (executeCommands sm hchan (Pid 0) CheckEverything prefix)
+        (emptyEnvironment, initModel, newCounter, initModel)
+    if reason0 /= Ok
+    then do
+      hist <- getChanContents hchan
+      let model = mkModel sm $ History hist
+      return (History hist, model, reason0)
+    else do
+      (errors, _) <- go (Map.empty, env0) suffixes
+      hist <- getChanContents hchan
+      let model = mkModel sm $ History hist
+      return (History hist, model, combineReasons $ Map.elems errors)
   where
     go res [] = return res
     go (previousErrors, env) (suffix : rest) = do
@@ -810,10 +751,10 @@ prettyParallelCommandsWithOpts :: (MonadIO m, Rank2.Foldable cmd)
                               => (Show (cmd Concrete), Show (resp Concrete))
                               => ParallelCommands cmd resp
                               -> Maybe GraphOptions
-                              -> [(History cmd resp, a, Logic)] -- ^ Output of 'runParallelCommands'.
+                              -> (History cmd resp, model Concrete, Logic) -- ^ Output of 'runParallelCommands'.
                               -> PropertyM m ()
-prettyParallelCommandsWithOpts cmds mGraphOptions histories = do
-  mapM_ (\(h, _, l) -> printCounterexample h (logic l) `whenFailM` property (boolean l)) histories
+prettyParallelCommandsWithOpts cmds mGraphOptions (h, _, l) = do
+  printCounterexample h (logic l) `whenFailM` property (boolean l)
     where
       printCounterexample hist' (VFalse ce) = do
         PP.putDoc $
@@ -821,12 +762,6 @@ prettyParallelCommandsWithOpts cmds mGraphOptions histories = do
            [ PP.line
            , PP.string (show $ toBoxDrawings cmds hist')
            , PP.string (show $ simplify ce)
-           , PP.line
-           , PP.line
-           , PP.string $
-             if or [ boolean l | (_, _, l) <- histories]
-             then "However, some repetitions of this sequence of commands passed. Maybe there is a race condition?"
-             else "And all repetitions of this sequence of commands failed. Maybe there is a logic bug? Try with more repetitions to be sure that it happens consistently"
            , PP.line
            ]
         case mGraphOptions of
@@ -849,7 +784,7 @@ prettyParallelCommands :: (Show (cmd Concrete), Show (resp Concrete))
                        => MonadIO m
                        => Rank2.Foldable cmd
                        => ParallelCommands cmd resp
-                       -> [(History cmd resp, a, Logic)] -- ^ Output of 'runNParallelCommands'.
+                       -> (History cmd resp, model Concrete, Logic) -- ^ Output of 'runParallelCommands'.
                        -> PropertyM m ()
 prettyParallelCommands cmds = prettyParallelCommandsWithOpts cmds Nothing
 
@@ -860,22 +795,16 @@ prettyNParallelCommandsWithOpts :: (Show (cmd Concrete), Show (resp Concrete))
                                 => Rank2.Foldable cmd
                                 => NParallelCommands cmd resp
                                 -> Maybe GraphOptions
-                                -> [(History cmd resp, a, Logic)] -- ^ Output of 'runNParallelCommands'.
+                                -> (History cmd resp, model Concrete, Logic) -- ^ Output of 'runNParallelCommands'.
                                 -> PropertyM m ()
-prettyNParallelCommandsWithOpts cmds mGraphOptions histories =
-   mapM_ (\(h, _, l) -> printCounterexample h (logic l) `whenFailM` property (boolean l)) histories
+prettyNParallelCommandsWithOpts cmds mGraphOptions (h, _, l) =
+   printCounterexample h (logic l) `whenFailM` property (boolean l)
     where
       printCounterexample hist' (VFalse ce) = do
         PP.putDoc $
           mconcat
            [ PP.line
            , PP.string (show $ simplify ce)
-           , PP.line
-           , PP.line
-           , PP.string $
-             if or [ boolean l | (_, _, l) <- histories]
-             then "However, some repetitions of this sequence of commands passed. Maybe there is a race condition?"
-             else "And all repetitions of this sequence of commands failed. Maybe there is a logic bug? Try with more repetitions to be sure that it happens consistently"
            , PP.line
            ]
         case mGraphOptions of
@@ -888,7 +817,7 @@ prettyNParallelCommands :: (Show (cmd Concrete), Show (resp Concrete))
                         => MonadIO m
                         => Rank2.Foldable cmd
                         => NParallelCommands cmd resp
-                        -> [(History cmd resp, a, Logic)] -- ^ Output of 'runNParallelCommands'.
+                        -> (History cmd resp, model Concrete, Logic) -- ^ Output of 'runNParallelCommands'.
                         -> PropertyM m ()
 prettyNParallelCommands cmds = prettyNParallelCommandsWithOpts cmds Nothing
 

--- a/src/Test/StateMachine/Sequential.hs
+++ b/src/Test/StateMachine/Sequential.hs
@@ -62,7 +62,8 @@ import           Control.Exception
 import           Control.Monad
                    (when)
 import           Control.Monad.Catch
-                   (MonadCatch, MonadMask, catch, ExitCase (..), generalBracket)
+                   (ExitCase(..), MonadCatch, MonadMask, catch,
+                   generalBracket)
 import           Control.Monad.State.Strict
                    (StateT, evalStateT, get, lift, put, runStateT)
 import           Data.Bifunctor

--- a/src/Test/StateMachine/Types/Rank2.hs
+++ b/src/Test/StateMachine/Types/Rank2.hs
@@ -25,8 +25,9 @@ import           Data.Kind
                    (Type)
 import qualified Data.Traversable    as Rank1
 import           GHC.Generics
-                   ((:*:)((:*:)), (:+:)(L1, R1), Generic1, K1(K1),
-                   M1(M1), Rec1(Rec1), Rep1, U1(U1), from1, to1, (:.:)(Comp1))
+                   (Generic1, K1(K1), M1(M1), Rec1(Rec1), Rep1, U1(U1),
+                   from1, to1, (:*:)((:*:)), (:+:)(L1, R1),
+                   (:.:)(Comp1))
 import           Prelude             hiding
                    (Applicative(..), Foldable(..), Functor(..),
                    Traversable(..), (<$>))

--- a/src/Test/StateMachine/Utils.hs
+++ b/src/Test/StateMachine/Utils.hs
@@ -41,7 +41,8 @@ module Test.StateMachine.Utils
 
 import           Prelude
 
-import           Data.Bifunctor (second)
+import           Data.Bifunctor
+                   (second)
 import           Data.List
                    (foldl')
 import           Test.QuickCheck

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -386,8 +386,8 @@ demoNoRace   = demoNoRace'   crudWebserverDbPort
 
 prop_crudWebserverDbParallel :: Int -> Property
 prop_crudWebserverDbParallel port =
-  forAllParallelCommands sm Nothing $ \cmds -> monadic (ioProperty . runner port) $
-    prettyParallelCommands cmds =<< runParallelCommandsNTimes 30 sm cmds
+  forAllParallelCommandsNTimes sm Nothing 30 $ \cmds -> monadic (ioProperty . runner port) $
+    prettyParallelCommands cmds =<< runParallelCommands sm cmds
 
 demoRace' :: Int -> IO ()
 demoRace' port = withCrudWebserverDb Race port

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -36,7 +36,7 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
                    (monadicIO)
 import           UnliftIO
-                   (TVar, atomically, newTVarIO, readTVar, writeTVar)
+                   (TVar, atomically, newTVarIO, readTVar, writeTVar, liftIO)
 
 import           Test.StateMachine
 import           Test.StateMachine.TreeDiff
@@ -76,97 +76,88 @@ output (Env mBuf) = atomically $ do
 
 prop_echoOK :: Property
 prop_echoOK = forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
-    (hist, _, res) <- runCommandsWithSetup echoSM cmds
-    prettyCommands smUnused hist (res === Ok)
+    env <- liftIO $ mkEnv
+    let echoSM' = echoSM env
+    (hist, _, res) <- runCommands echoSM' cmds
+    prettyCommands echoSM' hist (res === Ok)
 
 prop_echoParallelOK :: Property
 prop_echoParallelOK = forAllParallelCommands smUnused Nothing $ \cmds -> monadicIO $ do
-    prettyParallelCommands cmds =<< runParallelCommandsWithSetup echoSM cmds
+    env <- liftIO $ mkEnv
+    let echoSM' = echoSM env
+    prettyParallelCommands cmds =<< runParallelCommands echoSM' cmds
 
 prop_echoNParallelOK :: Int -> Property
 prop_echoNParallelOK np = forAllNParallelCommands smUnused np $ \cmds -> monadicIO $ do
-    prettyNParallelCommands cmds =<< runNParallelCommandsWithSetup echoSM cmds
+    env <- liftIO $ mkEnv
+    let echoSM' = echoSM env
+    prettyNParallelCommands cmds =<< runNParallelCommands echoSM' cmds
 
 smUnused :: StateMachine Model Action IO Response
-smUnused = StateMachine
+smUnused = echoSM $ error "used env during command generation"
+
+echoSM :: Env -> StateMachine Model Action IO Response
+echoSM env = StateMachine
     { initModel = Empty -- At the beginning of time nothing was received.
-    , transition = transitions
-    , precondition = preconditions
-    , postcondition = postconditions
-    , QC.generator = Echo.generator
+    , transition = mTransitions
+    , precondition = mPreconditions
+    , postcondition = mPostconditions
+    , generator = mGenerator
     , invariant = Nothing
-    , QC.shrinker = Echo.shrinker
-    , QC.semantics = e
-    , QC.mock = Echo.mock
+    , shrinker = mShrinker
+    , semantics = mSemantics
+    , mock = mMock
     , cleanup = noCleanup
     }
-  where
-    e = error "SUT must not be used"
+    where
+      mTransitions :: Model r -> Action r -> Response r -> Model r
+      mTransitions Empty   (In str) _   = Buf str
+      mTransitions (Buf _) Echo     _   = Empty
+      mTransitions Empty   Echo     _   = Empty
+      -- TODO: qcsm will match the case below. However we don't expect this to happen!
+      mTransitions (Buf str) (In _)   _ = Buf str -- Dummy response
+          -- error "This shouldn't happen: input transition with full buffer"
 
-echoSM :: IO (StateMachine Model Action IO Response)
-echoSM  = do
-  env <- mkEnv
-  pure $ StateMachine
-    { initModel = Empty -- At the beginning of time nothing was received.
-    , transition = transitions
-    , precondition = preconditions
-    , postcondition = postconditions
-    , QC.generator = Echo.generator
-    , invariant = Nothing
-    , QC.shrinker = Echo.shrinker
-    , QC.semantics = Echo.semantics env
-    , QC.mock = Echo.mock
-    , cleanup = noCleanup
-    }
+      -- | There are no preconditions for this model.
+      mPreconditions :: Model Symbolic -> Action Symbolic -> Logic
+      mPreconditions _ _ = Top
 
-transitions :: Model r -> Action r -> Response r -> Model r
-transitions Empty   (In str) _   = Buf str
-transitions (Buf _) Echo     _   = Empty
-transitions Empty   Echo     _   = Empty
--- TODO: qcsm will match the case below. However we don't expect this to happen!
-transitions (Buf str) (In _)   _ = Buf str -- Dummy response
-    -- error "This shouldn't happen: input transition with full buffer"
+      -- | Post conditions for the system.
+      mPostconditions :: Model Concrete -> Action Concrete -> Response Concrete -> Logic
+      mPostconditions Empty     (In _) InAck     = Top
+      mPostconditions (Buf _)   (In _) ErrFull   = Top
+      mPostconditions _         (In _) _         = Bot
+      mPostconditions Empty     Echo   ErrEmpty  = Top
+      mPostconditions Empty     Echo   _         = Bot
+      mPostconditions (Buf str) Echo   (Out out) = str .== out
+      mPostconditions (Buf _)   Echo   _         = Bot
 
--- | There are no preconditions for this model.
-preconditions :: Model Symbolic -> Action Symbolic -> Logic
-preconditions _ _ = Top
+      -- | Generator for symbolic actions.
+      mGenerator :: Model Symbolic -> Maybe (Gen (Action Symbolic))
+      mGenerator _ =  Just $ oneof
+          [ In <$> arbitrary
+          , return Echo
+          ]
 
--- | Post conditions for the system.
-postconditions :: Model Concrete -> Action Concrete -> Response Concrete -> Logic
-postconditions Empty     (In _) InAck     = Top
-postconditions (Buf _)   (In _) ErrFull   = Top
-postconditions _         (In _) _         = Bot
-postconditions Empty     Echo   ErrEmpty  = Top
-postconditions Empty     Echo   _         = Bot
-postconditions (Buf str) Echo   (Out out) = str .== out
-postconditions (Buf _)   Echo   _         = Bot
+      -- | Trivial shrinker.
+      mShrinker :: Model Symbolic -> Action Symbolic -> [Action Symbolic]
+      mShrinker _ _ = []
 
--- | Generator for symbolic actions.
-generator :: Model Symbolic -> Maybe (Gen (Action Symbolic))
-generator _ =  Just $ oneof
-    [ In <$> arbitrary
-    , return Echo
-    ]
+      -- | Here we'd do the dispatch to the actual SUT.
+      mSemantics :: Action Concrete -> IO (Response Concrete)
+      mSemantics (In str) = do
+          success <- input env str
+          return $ if success
+                   then InAck
+                   else ErrFull
+      mSemantics Echo = maybe ErrEmpty Out <$> output env
 
--- | Trivial shrinker.
-shrinker :: Model Symbolic -> Action Symbolic -> [Action Symbolic]
-shrinker _ _ = []
-
--- | Here we'd do the dispatch to the actual SUT.
-semantics :: Env -> Action Concrete -> IO (Response Concrete)
-semantics env (In str) = do
-    success <- input env str
-    return $ if success
-             then InAck
-             else ErrFull
-semantics env Echo = maybe ErrEmpty Out <$> output env
-
--- | What is the mock for?
-mock :: Model Symbolic -> Action Symbolic -> GenSym (Response Symbolic)
-mock Empty (In _)   = return InAck
-mock (Buf _) (In _) = return ErrFull
-mock Empty Echo     = return ErrEmpty
-mock (Buf str) Echo = return (Out str)
+      -- | What is the mock for?
+      mMock :: Model Symbolic -> Action Symbolic -> GenSym (Response Symbolic)
+      mMock Empty (In _)   = return InAck
+      mMock (Buf _) (In _) = return ErrFull
+      mMock Empty Echo     = return ErrEmpty
+      mMock (Buf str) Echo = return (Out str)
 
 deriving anyclass instance ToExpr (Model Concrete)
 

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -36,7 +36,8 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
                    (monadicIO)
 import           UnliftIO
-                   (TVar, atomically, newTVarIO, readTVar, writeTVar, liftIO)
+                   (TVar, atomically, liftIO, newTVarIO, readTVar,
+                   writeTVar)
 
 import           Test.StateMachine
 import           Test.StateMachine.TreeDiff

--- a/test/MemoryReference.hs
+++ b/test/MemoryReference.hs
@@ -224,7 +224,7 @@ prop_parallel bug = forAllParallelCommands sm' Nothing $
 
 prop_parallel' :: Bug -> Property
 prop_parallel' bug = forAllParallelCommands sm' Nothing $ \cmds -> monadicIO $ do
-  prettyParallelCommands cmds =<< runParallelCommands' (pure sm') complete cmds
+  prettyParallelCommands cmds =<< runParallelCommands' sm' complete cmds
     where
       sm' = sm bug
       complete :: Command Concrete -> Response Concrete

--- a/test/Schema.hs
+++ b/test/Schema.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE DerivingStrategies            #-}
-{-# LANGUAGE GADTs                         #-}
-{-# LANGUAGE ScopedTypeVariables           #-}
-{-# LANGUAGE OverloadedStrings             #-}
-{-# LANGUAGE MultiParamTypeClasses         #-}
-{-# LANGUAGE TypeFamilies                  #-}
-{-# LANGUAGE TypeOperators                 #-}
-{-# LANGUAGE TemplateHaskell               #-}
-{-# LANGUAGE QuasiQuotes                   #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving    #-}
-{-# LANGUAGE UndecidableInstances          #-}
-{-# LANGUAGE FlexibleInstances             #-}
-{-# LANGUAGE DeriveGeneric                 #-}
-{-# LANGUAGE RecordWildCards               #-}
-{-# LANGUAGE StandaloneDeriving            #-}
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 module Schema
     ( Person (..)

--- a/test/ShrinkingProps.hs
+++ b/test/ShrinkingProps.hs
@@ -705,10 +705,9 @@ prop_one_thread n = forAllCommands sm Nothing $ \cmds -> monadicIO $ do
           cmdsChucks = chunksOf n' sx
           sfxs = (\c -> [c]) . QSM.Commands <$> cmdsChucks
           nParallelCmd = QSM.ParallelCommands {prefix = QSM.Commands px, suffixes = sfxs}
-      res <- runNParallelCommandsNTimes 1 sm nParallelCmd
-      let (hist', _ret) = unzip [ (a, c) | (a, _, c) <- res ]
-      let events = snd <$> (QSM.unHistory hist)
-          events' = snd <$> (concat (QSM.unHistory <$> hist'))
+      (hist', _, _ret) <- runNParallelCommands sm nParallelCmd
+      let events = snd <$> QSM.unHistory hist
+          events' = snd <$> QSM.unHistory hist'
       return $ cmpList equalH events' events
 
 {-------------------------------------------------------------------------------

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -19,10 +19,10 @@ import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
                    (expectFailure, testProperty, withMaxSuccess)
 
-import           Bookstore                as Store
+import           Bookstore             as Store
 import           CircularBuffer
 import           Cleanup
-import qualified CrudWebserverDb          as WS
+import qualified CrudWebserverDb       as WS
 import           DieHard
 import           Echo
 import           ErrorEncountered

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -37,8 +37,6 @@ import           SQLite
 import           TicketDispenser
 import qualified UnionFind
 
--- RQlite tests fail, see #14
-
 ------------------------------------------------------------------------
 
 tests :: Bool -> TestTree
@@ -107,15 +105,13 @@ tests docker0 = testGroup "Tests"
         $ expectFailure $ withMaxSuccess 1000 $ prop_parallel_clean     (Eq True)  Cleanup.NoBug     NoOp
 
       , testProperty "3-threadsRegularNoOp"   $ prop_nparallel_clean  3 Regular    Cleanup.NoBug     NoOp
-      , testProperty "3-threadsRegular"
-        $ expectFailure                       $ prop_nparallel_clean  3 Regular    Cleanup.NoBug     ReDo
+      , testProperty "3-threadsRegular"       $ prop_nparallel_clean  3 Regular    Cleanup.NoBug     ReDo
       , testProperty "3-threadsRegularExc"    $ expectFailure
                                               $ prop_nparallel_clean  3 Regular    Cleanup.Exception NoOp
       , testProperty "3-threadsRegularExc"
         $ expectFailure                       $ prop_nparallel_clean  3 Regular    Cleanup.Exception ReDo
       , testProperty "3-threadsFilesNoOp"     $ prop_nparallel_clean  3 Files      Cleanup.NoBug     NoOp
-      , testProperty "3-threadsFiles"
-        $ expectFailure                       $ prop_nparallel_clean  3 Files      Cleanup.NoBug     ReDo
+      , testProperty "3-threadsFiles"         $ prop_nparallel_clean  3 Files      Cleanup.NoBug     ReDo
       , testProperty "3-threadsFilesExcNoOp"  $ prop_nparallel_clean  3 Files      Cleanup.Exception NoOp
       , testProperty "3-threadsFilesExc"
         $ expectFailure $ withMaxSuccess 1000 $ prop_nparallel_clean  3 Files      Cleanup.Exception ReDo
@@ -127,13 +123,6 @@ tests docker0 = testGroup "Tests"
   , testGroup "SQLite"
       [ testProperty "Parallel" prop_parallel_sqlite
       ]
-  -- Rqlite tests fail, see #14
-  --, testGroup "Rqlite"
-  --    [ whenDocker docker0 "rqlite" $ testProperty "parallel" $ withMaxSuccess 10 $ prop_parallel_rqlite (Just Weak)
-      -- we currently don't add other properties, because they interfere (Tasty runs tests on parallel)
-      -- , testProperty "sequential" $ withMaxSuccess 10   $ prop_sequential_rqlite (Just Weak)
-      -- , testProperty "sequential-stale" $ expectFailure $ prop_sequential_rqlite (Just RQlite.None)
-  --    ]
   , testGroup "ErrorEncountered"
       [ testProperty "Sequential" prop_error_sequential
       , testProperty "Parallel"   prop_error_parallel


### PR DESCRIPTION
This is an implementation of #42. In general it can be seen as a revert of #12 and #11. This also makes #40 and #41 not necessary.

I would recommend isolating only a2f27d1314a2809e278c8948bfc7e55d33afdece to view the relevant changes, the other commit just modifies the tests.

It is however important to note that in the tests I had a bunch of troubles with `Cleanup` because it tries to test the internals of QSM, by assuming multiple repetitions in place. I'm open to discussion on how to best do this. For now as that one was using 2 repetitions I'm running the parallel machine two times.