### PR TITLE
Use `io-classes` instead of `unliftio`

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -63,7 +63,6 @@ library no-vendored-treediff
     , base        >=4.10    && <5
     , containers  >=0.5.7.1 && <0.8
     , directory   >=1.0.0.0 && <1.4
-    , exceptions  >=0.8.3   && <0.11
     , filepath    >=1.0     && <1.6
     , mtl         >=2.2.1   && <2.4
     , text        >=1.2.3.1 && <2.2
@@ -78,7 +77,7 @@ library no-vendored-treediff
     , random                       >=1.1         && <1.3
     , sop-core                     >=0.5.0.2     && <0.6
     , split                        >=0.2.3.5     && <0.3
-    , unliftio                     >=0.2.7.0     && <0.3
+    , io-classes                   >=1           && <1.6
 
   default-language: Haskell2010
 


### PR DESCRIPTION
[`io-classes`](https://hackage.haskell.org/package/io-classes-1.5.0.0) is a drop-in replacement for IO that allows to run code in `IOSim` which can simulate most aspects of `IO` ([see](https://hackage.haskell.org/package/io-sim)).